### PR TITLE
refactor(cli): one command, grouped the way Core groups its own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,9 @@ jobs:
 
       - name: Train with the built-in baselines
         run: |
-          /tmp/base/bin/goldilocks-train run protocols/synthetic/regression.toml \
+          /tmp/base/bin/goldilocks-ml train run protocols/synthetic/regression.toml \
             --dataset tests/fixtures/kdist --output /tmp/run/regression
-          /tmp/base/bin/goldilocks-train run protocols/synthetic/classification.toml \
+          /tmp/base/bin/goldilocks-ml train run protocols/synthetic/classification.toml \
             --dataset tests/fixtures/metallic --output /tmp/run/classification
           test -f /tmp/run/regression/metrics.json
           test -f /tmp/run/classification/metrics.json

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ can run both reference workflows entirely offline:
 
 ```bash
 uv sync
-uv run goldilocks-train validate protocols/synthetic/regression.toml \
+uv run goldilocks-ml train validate protocols/synthetic/regression.toml \
   --dataset tests/fixtures/kdist
-uv run goldilocks-train run protocols/synthetic/regression.toml \
+uv run goldilocks-ml train run protocols/synthetic/regression.toml \
   --dataset tests/fixtures/kdist --output local_runs/synthetic-regression
 ```
 
@@ -43,13 +43,13 @@ Install the repository environment and inspect the CLI:
 
 ```bash
 uv sync --group dev --group docs
-uv run goldilocks-psdi --help
+uv run goldilocks-ml publish --help
 ```
 
 Validate a deposit without making a network request:
 
 ```bash
-uv run goldilocks-psdi validate deposits/kmesh/qrf95 \
+uv run goldilocks-ml publish validate deposits/kmesh/qrf95 \
   --artifact-directory local_data/models/kmesh/qrf95
 ```
 

--- a/deposits/README.md
+++ b/deposits/README.md
@@ -13,14 +13,14 @@ model host or fallback source.
 Validate a locally cached artifact before making any network request:
 
 ```bash
-uv run goldilocks-psdi validate deposits/kmesh/qrf95 \
+uv run goldilocks-ml publish validate deposits/kmesh/qrf95 \
   --artifact-directory /path/to/qrf95-snapshot
 ```
 
 Create a draft on PSDI:
 
 ```bash
-uv run goldilocks-psdi upload deposits/kmesh/qrf95 \
+uv run goldilocks-ml publish upload deposits/kmesh/qrf95 \
   --artifact-directory /path/to/qrf95-snapshot \
   --token-file "$HOME/.config/goldilocks-ml/psdi.token" \
   --confirm-upload

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,12 +1,27 @@
 # CLI reference
 
-Run commands from a clone with `uv run`. `goldilocks-train` trains and
-evaluates models; `goldilocks-psdi` publishes them.
+One command, grouped by responsibility: a group names what you are working
+with, a command names what to do to it.
 
-## `goldilocks-train seal`
+```
+goldilocks-ml train    seal | validate | run
+goldilocks-ml publish  validate | checksum | upload
+```
+
+Run them from a clone with `uv run`.
+
+Grouping disambiguates a word that means two things. `train validate` checks a
+protocol against a snapshot; `publish validate` checks a deposit against its
+artifacts.
+
+**There is no inference command.** Predicting from a published model is what
+Goldilocks Core does, and this package gives it a library rather than a second
+command line. See [Use a model](inference.md).
+
+## `goldilocks-ml train seal`
 
 ```bash
-uv run goldilocks-train seal DATASET \
+uv run goldilocks-ml train seal DATASET \
   --record-id RECORD --version VERSION \
   --target TARGET --target-contract CONTRACT \
   --target-definition DEFINITION [--target-units UNITS]
@@ -15,20 +30,20 @@ uv run goldilocks-train seal DATASET \
 Writes `manifest.json` with the snapshot identity, target definition, and the
 size and SHA-256 of every file. This command makes no network request.
 
-## `goldilocks-train validate`
+## `goldilocks-ml train validate`
 
 ```bash
-uv run goldilocks-train validate PROTOCOL --dataset DATASET
+uv run goldilocks-ml train validate PROTOCOL --dataset DATASET
 ```
 
 Loads the protocol, verifies the dataset snapshot's identity, checksums, and
 required columns, derives the split, and reports the per-split sample counts.
 It trains nothing and makes no network request.
 
-## `goldilocks-train run`
+## `goldilocks-ml train run`
 
 ```bash
-uv run goldilocks-train run PROTOCOL --dataset DATASET --output OUTPUT \
+uv run goldilocks-ml train run PROTOCOL --dataset DATASET --output OUTPUT \
   [--splits SPLITS] [--overwrite]
 ```
 
@@ -41,29 +56,29 @@ even when the flag is present.
 See [Train a model](training/index.md) for the protocol schema, the
 snapshot contract, and the bundle layout.
 
-## `goldilocks-psdi checksum`
+## `goldilocks-ml publish checksum`
 
 ```bash
-uv run goldilocks-psdi checksum PATH
+uv run goldilocks-ml publish checksum PATH
 ```
 
 Prints the artifact basename, byte size, and SHA-256 as a JSON manifest entry.
 It reads the local file and makes no network request.
 
-## `goldilocks-psdi validate`
+## `goldilocks-ml publish validate`
 
 ```bash
-uv run goldilocks-psdi validate DEPOSITION \
+uv run goldilocks-ml publish validate DEPOSITION \
   --artifact-directory ARTIFACT_DIRECTORY
 ```
 
 Validates metadata and every upload file offline. `DEPOSITION` contains the
 three sidecars; `ARTIFACT_DIRECTORY` contains the files listed in the manifest.
 
-## `goldilocks-psdi upload`
+## `goldilocks-ml publish upload`
 
 ```bash
-uv run goldilocks-psdi upload DEPOSITION \
+uv run goldilocks-ml publish upload DEPOSITION \
   --artifact-directory ARTIFACT_DIRECTORY \
   --token-file TOKEN_FILE \
   --confirm-upload

--- a/docs/deposit-format.md
+++ b/docs/deposit-format.md
@@ -46,12 +46,12 @@ Each artifact entry has three fields:
 | `size_bytes` | Exact integer file size in bytes, not the rounded MB shown by a web page |
 | `sha256` | 64-character lowercase digest calculated from the complete file contents |
 
-Run `goldilocks-psdi checksum PATH` on the final file to generate all three
+Run `goldilocks-ml publish checksum PATH` on the final file to generate all three
 values together. A model with multiple required files needs one artifact entry
 per file.
 
 Artifact names must be basenames, not paths. Generate each entry from the final
-file with `goldilocks-psdi checksum`; do not reuse a digest from an unverified or
+file with `goldilocks-ml publish checksum`; do not reuse a digest from an unverified or
 re-serialized copy. Artifact names must not be `README.md`, `manifest.json`, or
 `metadata.json`, which are reserved for the deposit sidecars.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,10 +21,10 @@ Complete the [installation](installation.md) before preparing a publication.
 There are two different things:
 
 - the **PSDI token** is the secret text issued by the PSDI website;
-- `goldilocks-psdi.token` is a local text file that you create to hold that
+- `goldilocks-ml publish.token` is a local text file that you create to hold that
   secret for the upload CLI.
 
-PSDI does not create or download the `goldilocks-psdi.token` file for you.
+PSDI does not create or download the `goldilocks-ml publish.token` file for you.
 
 ### Create the PSDI token
 
@@ -33,7 +33,7 @@ PSDI does not create or download the `goldilocks-psdi.token` file for you.
 3. Create a personal access token and copy the token value when PSDI displays
    it. Treat it like a password.
 
-### Create `goldilocks-psdi.token` locally
+### Create `goldilocks-ml publish.token` locally
 
 Copy the complete block below into a Bash or Zsh terminal and run it. Do not
 replace `psdi_token` in the commands with the secret itself.
@@ -107,7 +107,7 @@ fields and review checklist.
 Generate a manifest entry for every artifact:
 
 ```bash
-uv run goldilocks-psdi checksum \
+uv run goldilocks-ml publish checksum \
   local_data/models/<task>/<model>/model-file.bin
 ```
 
@@ -132,7 +132,7 @@ For example, the CGCNN deposit has separate entries for `is_metal.ckpt` and
 Validation makes no network request:
 
 ```bash
-uv run goldilocks-psdi validate deposits/<task>/<model> \
+uv run goldilocks-ml publish validate deposits/<task>/<model> \
   --artifact-directory local_data/models/<task>/<model>
 ```
 
@@ -151,7 +151,7 @@ Do not proceed until this succeeds.
 Create a draft on PSDI:
 
 ```bash
-uv run goldilocks-psdi upload deposits/<task>/<model> \
+uv run goldilocks-ml publish upload deposits/<task>/<model> \
   --artifact-directory local_data/models/<task>/<model> \
   --token-file "$HOME/.config/goldilocks-ml/psdi.token" \
   --confirm-upload

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,8 +28,8 @@ uv sync
 Both command-line tools should display their help:
 
 ```bash
-uv run goldilocks-train --help
-uv run goldilocks-psdi --help
+uv run goldilocks-ml train --help
+uv run goldilocks-ml publish --help
 ```
 
 Continue with [Train a model](training/index.md) or

--- a/docs/training/index.md
+++ b/docs/training/index.md
@@ -13,9 +13,9 @@ The repository includes pinned synthetic regression and classification
 snapshots. They exercise the installed package, not test-only substitutes:
 
 ```bash
-uv run goldilocks-train validate protocols/synthetic/regression.toml \
+uv run goldilocks-ml train validate protocols/synthetic/regression.toml \
   --dataset tests/fixtures/kdist
-uv run goldilocks-train run protocols/synthetic/regression.toml \
+uv run goldilocks-ml train run protocols/synthetic/regression.toml \
   --dataset tests/fixtures/kdist --output local_runs/synthetic-regression
 ```
 
@@ -28,16 +28,16 @@ implemented yet.
 
 ```bash
 # 1. Convert your data, then record a digest for every file.
-uv run goldilocks-train seal snapshots/mine \
+uv run goldilocks-ml train seal snapshots/mine \
   --record-id my-data --version v1 \
   --target energy --target-contract my-project.energy.v1 \
   --target-definition "Total energy per atom." --target-units eV/atom
 
 # 2. Check the protocol and your data. Trains nothing, contacts nothing.
-uv run goldilocks-train validate PROTOCOL --dataset snapshots/mine
+uv run goldilocks-ml train validate PROTOCOL --dataset snapshots/mine
 
 # 3. Train, evaluate, and write the bundle.
-uv run goldilocks-train run PROTOCOL --dataset snapshots/mine \
+uv run goldilocks-ml train run PROTOCOL --dataset snapshots/mine \
   --output local_runs/mine-v1
 ```
 

--- a/docs/training/kmesh/qrf95.md
+++ b/docs/training/kmesh/qrf95.md
@@ -104,10 +104,10 @@ Prepare and seal a snapshot with stable sample IDs, CIF files, and a composition
 group in the third `id_prop.csv` column. Then run:
 
 ```bash
-uv run goldilocks-train validate protocols/kmesh/qrf95.toml \
+uv run goldilocks-ml train validate protocols/kmesh/qrf95.toml \
   --dataset SNAPSHOT --artifact-directory ARTIFACTS
 
-uv run goldilocks-train run protocols/kmesh/qrf95.toml \
+uv run goldilocks-ml train run protocols/kmesh/qrf95.toml \
   --dataset SNAPSHOT --artifact-directory ARTIFACTS \
   --output local_runs/qrf95-v1
 ```

--- a/docs/training/your-data.md
+++ b/docs/training/your-data.md
@@ -36,7 +36,7 @@ Omit it and the snapshot supports random splitting only.
 ## Seal the directory
 
 ```bash
-uv run goldilocks-train seal snapshots/mine --record-id my-data --version v1 \
+uv run goldilocks-ml train seal snapshots/mine --record-id my-data --version v1 \
   --target k_distance \
   --target-contract my-project.k-distance.v1 \
   --target-definition "Maximum adjacent reciprocal-space k-point spacing." \

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,7 +32,7 @@ edit the digest to silence the error until you determine why the file changed.
 Common causes are retraining, re-serialization, downloading a different model
 version, or using the wrong artifact directory.
 
-Run `goldilocks-psdi checksum` on the intended final artifact and review the
+Run `goldilocks-ml publish checksum` on the intended final artifact and review the
 corresponding model card and inference requirements before updating the manifest.
 
 ## Upload fails

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ qrf95 = [
 ]
 
 [project.scripts]
-goldilocks-psdi = "goldilocks_ml.psdi:cli"
-goldilocks-train = "goldilocks_ml.cli:cli"
+goldilocks-ml = "goldilocks_ml.console:main"
 
 [dependency-groups]
 dev = [

--- a/src/goldilocks_ml/cli.py
+++ b/src/goldilocks_ml/cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
@@ -437,11 +436,16 @@ def execute(
     return {"directory": directory, "metrics": metrics, "manifest": manifest}
 
 
-def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+def add_parser(groups: argparse._SubParsersAction) -> None:
+    """Register the ``train`` group on the shared command line."""
+    parser = groups.add_parser(
+        "train",
+        help="seal a snapshot, validate a protocol, and run a training job",
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    parser.set_defaults(handler=_run)
+    subparsers = parser.add_subparsers(dest="train_command", required=True)
 
     seal_parser = subparsers.add_parser(
         "seal", help="write manifest.json for a converted snapshot directory"
@@ -481,7 +485,7 @@ def _parser() -> argparse.ArgumentParser:
 
 def _run(args: argparse.Namespace) -> None:
 
-    if args.command == "seal":
+    if args.train_command == "seal":
         result = seal(
             args.snapshot,
             record_id=args.record_id,
@@ -504,7 +508,7 @@ def _run(args: argparse.Namespace) -> None:
     snapshot = load_snapshot(args.dataset, protocol)
     artifact_dir = artifact_store.artifact_directory(args.artifact_directory)
 
-    if args.command == "validate":
+    if args.train_command == "validate":
         features, _ = build_features(protocol, snapshot, artifact_dir)
         assignment = assign_splits(snapshot, protocol)
         sizes: dict[str, int] = {}
@@ -534,23 +538,3 @@ def _run(args: argparse.Namespace) -> None:
         f"(test {primary}: model {scores['model']['test'][primary]:.6g}, "
         f"baseline {scores['baseline']['test'][primary]:.6g})"
     )
-
-
-def cli() -> None:
-    """Run the training protocol command-line interface."""
-    args = _parser().parse_args()
-    try:
-        _run(args)
-    except (
-        ValueError,
-        FileNotFoundError,
-        FileExistsError,
-        NotADirectoryError,
-    ) as error:
-        # These carry an actionable message; a traceback would only bury it.
-        print(f"error: {error}", file=sys.stderr)
-        raise SystemExit(2) from error
-
-
-if __name__ == "__main__":
-    cli()

--- a/src/goldilocks_ml/console.py
+++ b/src/goldilocks_ml/console.py
@@ -1,0 +1,55 @@
+"""The `goldilocks-ml` command line.
+
+One binary, grouped by responsibility, matching the shape Goldilocks Core
+settles on: a group names what you are working with, a command names what to do
+to it. Training and publication are what this package is responsible for.
+Inference has no command here on purpose -- the side that issues that command
+is Core, and this package gives it a library.
+
+Grouping also disambiguates a word that means two things. `train validate`
+checks a protocol against a snapshot; `publish validate` checks a deposit
+against its artifacts. As separate binaries the difference was invisible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from goldilocks_ml import cli as training
+from goldilocks_ml import psdi as publication
+
+# Errors that carry an actionable message. A traceback would only bury it.
+REPORTED = (
+    ValueError,
+    FileNotFoundError,
+    FileExistsError,
+    NotADirectoryError,
+    PermissionError,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the parser with every group mounted."""
+    parser = argparse.ArgumentParser(
+        prog="goldilocks-ml",
+        description="Train, evaluate, and publish Goldilocks models.",
+    )
+    groups = parser.add_subparsers(dest="group", required=True)
+    training.add_parser(groups)
+    publication.add_parser(groups)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run one command."""
+    args = build_parser().parse_args(argv)
+    try:
+        args.handler(args)
+    except REPORTED as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/src/goldilocks_ml/psdi.py
+++ b/src/goldilocks_ml/psdi.py
@@ -276,12 +276,16 @@ def _add_remote_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+def add_parser(groups: argparse._SubParsersAction) -> None:
+    """Register the ``publish`` group on the shared command line."""
+    parser = groups.add_parser(
+        "publish",
+        help="validate and upload a model deposit to PSDI Data Collections",
         description=__doc__,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    parser.set_defaults(handler=_run)
+    subparsers = parser.add_subparsers(dest="publish_command", required=True)
 
     validate = subparsers.add_parser(
         "validate", help="validate metadata and artifact integrity offline"
@@ -304,10 +308,9 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def cli() -> None:
-    """Run the PSDI deposition command-line interface."""
-    args = _parser().parse_args()
-    if args.command == "checksum":
+def _run(args: argparse.Namespace) -> None:
+    """Carry out one publish command."""
+    if args.publish_command == "checksum":
         artifact = describe_artifact(args.artifact)
         print(
             json.dumps(
@@ -322,7 +325,7 @@ def cli() -> None:
         return
 
     deposition = load_deposition(args.deposition, args.artifact_directory)
-    if args.command == "validate":
+    if args.publish_command == "validate":
         names = ", ".join(deposition.files)
         print(f"Valid deposition for {deposition.community}: {names}")
         return
@@ -334,7 +337,3 @@ def cli() -> None:
         token=token,
     )
     print(f"Created and bound PSDI draft {draft_id}; review not submitted")
-
-
-if __name__ == "__main__":
-    cli()

--- a/src/goldilocks_ml/snapshot.py
+++ b/src/goldilocks_ml/snapshot.py
@@ -86,7 +86,8 @@ def _load_manifest(directory: Path) -> tuple[dict[str, Any], str]:
     manifest_path = directory / MANIFEST_NAME
     if not manifest_path.is_file():
         raise FileNotFoundError(
-            f"{manifest_path} is missing; run 'goldilocks-train seal' on the snapshot"
+            f"{manifest_path} is missing; run 'goldilocks-ml train seal' on "
+            "the snapshot"
         )
     digest = sha256_file(manifest_path)
     with manifest_path.open(encoding="utf-8") as handle:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for goldilocks-train seal, validate, and run."""
+"""End-to-end tests for goldilocks-ml train seal, validate, and run."""
 
 from __future__ import annotations
 
@@ -20,7 +20,8 @@ from conftest import (
     write_protocol,
 )
 
-from goldilocks_ml.cli import cli, seal
+from goldilocks_ml.cli import seal
+from goldilocks_ml.console import main
 from goldilocks_ml.runs import MANIFEST_NAME, RUN_MARKER
 
 BUNDLE_FILES = {
@@ -68,8 +69,8 @@ def _setup(
 
 
 def _run(monkeypatch: pytest.MonkeyPatch, *argv: str) -> None:
-    monkeypatch.setattr("sys.argv", ["goldilocks-train", *argv])
-    cli()
+    del monkeypatch  # the parser takes its arguments directly
+    main(["train", *argv])
 
 
 def _bundle_files(directory: Path) -> set[str]:

--- a/tests/test_psdi.py
+++ b/tests/test_psdi.py
@@ -8,11 +8,11 @@ from pathlib import Path
 
 import pytest
 
+from goldilocks_ml.console import main
 from goldilocks_ml.psdi import (
     PSDI_API,
     Deposition,
     DraftCleanupError,
-    cli,
     create_deposition,
     describe_artifact,
     load_deposition,
@@ -381,9 +381,9 @@ def test_checksum_cli_prints_manifest_entry(
 ) -> None:
     artifact = tmp_path / "model.bin"
     artifact.write_bytes(b"model")
-    monkeypatch.setattr("sys.argv", ["goldilocks-psdi", "checksum", str(artifact)])
+    del monkeypatch  # the parser takes its arguments directly
 
-    cli()
+    main(["publish", "checksum", str(artifact)])
 
     assert json.loads(capsys.readouterr().out) == {
         "name": "model.bin",
@@ -396,18 +396,11 @@ def test_validate_cli_reports_verified_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     directory, artifacts = _write_deposition(tmp_path)
-    monkeypatch.setattr(
-        "sys.argv",
-        [
-            "goldilocks-psdi",
-            "validate",
-            str(directory),
-            "--artifact-directory",
-            str(artifacts),
-        ],
-    )
+    del monkeypatch  # the parser takes its arguments directly
 
-    cli()
+    main(
+        ["publish", "validate", str(directory), "--artifact-directory", str(artifacts)]
+    )
 
     output = capsys.readouterr().out
     assert "Valid deposition for data-to-knowledge" in output
@@ -428,10 +421,9 @@ def test_upload_cli_creates_draft_without_submitting_review(
         return "draft-2"
 
     monkeypatch.setattr("goldilocks_ml.psdi.create_deposition", fake_create)
-    monkeypatch.setattr(
-        "sys.argv",
+    main(
         [
-            "goldilocks-psdi",
+            "publish",
             "upload",
             str(directory),
             "--artifact-directory",
@@ -439,10 +431,8 @@ def test_upload_cli_creates_draft_without_submitting_review(
             "--token-file",
             str(token_file),
             "--confirm-upload",
-        ],
+        ]
     )
-
-    cli()
 
     assert len(calls) == 1
     assert calls[0][0].community == "data-to-knowledge"

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -217,7 +217,7 @@ def test_load_snapshot_rejects_a_missing_manifest(
     build_snapshot(snapshot_dir)
     (snapshot_dir / "manifest.json").unlink()
 
-    with pytest.raises(FileNotFoundError, match="goldilocks-train seal"):
+    with pytest.raises(FileNotFoundError, match="goldilocks-ml train seal"):
         _load(tmp_path, snapshot_dir)
 
 


### PR DESCRIPTION
Two binaries named after verbs sat oddly beside Core, which is settling on one binary where a group names what you are working with and a command names what to do to it. This package now reads the same way:

    goldilocks-ml train    seal | validate | run
    goldilocks-ml publish  validate | checksum | upload

The grouping also fixes a word that meant two things. `goldilocks-train validate` checked a protocol against a snapshot and `goldilocks-psdi validate` checked a deposit against its artifacts; as separate binaries nothing said so.

No compatibility aliases. The package is not published yet, so nothing outside this repository can be depending on the old names, and Core is making the same clean break with its own.

There is deliberately no inference command. The side that issues that command is Core, and this package gives it a library instead. The reference says so rather than leaving a reader to wonder what is missing.

The tests now call the parser with an argument list instead of monkeypatching `sys.argv`, which is what the entry point does anyway.