### PR TITLE
docs: write for someone who has not met this project

### DIFF
--- a/docs/deposit-format.md
+++ b/docs/deposit-format.md
@@ -1,7 +1,10 @@
 # Deposit format
 
-A release consists of tracked sidecars and untracked artifacts. Together they
-identify the exact model files and the requirements for using them correctly.
+Publishing a model means publishing two different kinds of thing: the model
+file itself, which is large and stays out of version control, and a few small
+files describing it, which are committed alongside the code.
+
+This page is what those small files have to contain.
 
 ## Directory layout
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,54 +1,78 @@
 # Goldilocks ML
 
-Train, evaluate, and publish the models Goldilocks uses to recommend DFT
-inputs.
+Setting up a DFT calculation means choosing things that are hard to choose
+well. How dense does the k-point mesh need to be? Is this material a metal, so
+that it needs smearing? Too coarse and the answer is wrong; too fine and you
+burn compute for nothing.
 
-A model here is not a file someone produced once. It is a versioned protocol
-that pins its dataset, its split, its trainer, and its metrics; a run bundle
-recording what happened; and a published record anyone can verify by digest.
+Goldilocks answers those questions with models trained on past calculations.
+**This site is where those models are made.**
 
-!!! tip "Looking for a k-point mesh, not a model?"
+!!! tip "Just want the answers, not the models?"
 
     Then you want [Goldilocks Core](https://github.com/stfc/goldilocks-core).
-    It fetches the published models, runs them, and writes the input files.
-    This site is for the other side: producing the models it uses.
+    Give it a structure and it downloads the right model, runs it, and writes
+    your input files. You never touch this repository.
 
-## Train a model on your own data
+    Read on if you want to train a model yourself — on your own calculations,
+    your own chemistry, or your own definition of "converged".
+
+## Try it in one command
 
 ```bash
 uv run goldilocks-ml train run protocols/synthetic/regression.toml \
   --dataset tests/fixtures/kdist --output local_runs/first
 ```
 
-That runs end to end on a snapshot shipped with the repository, and writes a
-bundle recording what data was used, how it was split, what was fitted, how it
-scored against a baseline, and a SHA-256 for every file it read or wrote.
+That trains a model on a small dataset included with the repository, so it
+works before you have prepared anything of your own.
 
-Then bring your own: a protocol is an executable TOML file, and
-[Prepare your data](training/your-data.md) is the layout it expects.
+Look in `local_runs/first`. Every training run leaves a folder like it,
+containing:
 
-## Publish it
+- what the model predicted for each sample, next to the true value;
+- which samples went into training, validation, and testing;
+- how it scored, and how a trivial baseline scored on the same data;
+- a checksum for every file it read or wrote.
+
+The last two matter more than they sound. A score means nothing without knowing
+what a naive guess would have got, and six months from now the checksums are
+how you prove which data produced which model.
+
+## Train on your own data
+
+You describe a training job in a small configuration file — which dataset,
+how to split it, which model, which metrics — and run it. Nothing is decided in
+a notebook and forgotten.
+
+[Prepare your data](training/your-data.md) covers the format your calculations
+need to be in. [Train a model](training/index.md) walks through a real one.
+
+## Share what you trained
 
 ```bash
 uv run goldilocks-ml publish validate deposits/kmesh/qrf95 \
   --artifact-directory local_data/models/kmesh/qrf95
 ```
 
-Validation is offline and complete before anything reaches the network. The
-[publishing guide](publishing.md) covers the whole path to a reviewed PSDI
-record.
+Publishing puts a model in [PSDI Data
+Collections](https://data-collections.psdi.ac.uk) with a permanent identifier,
+so other people can cite it and check they have the same file you did.
+Everything is checked locally before anything is uploaded, and nothing is ever
+submitted for review without you looking at it first.
+
+[Publishing a model](publishing.md) is the full walkthrough.
 
 ## Models published this way
 
-Both records passed review by the PSDI Data to Knowledge community.
-
-| Model | Predicts | Record |
+| Model | Answers | Record |
 | --- | --- | --- |
-| QRF95 | k-point distance, with a 90% interval | [fex36-67b11](https://data-collections.psdi.ac.uk/records/fex36-67b11) |
-| CGCNN | metallicity | [ptc95-vbq12](https://data-collections.psdi.ac.uk/records/ptc95-vbq12) |
+| QRF95 | how dense a k-point mesh needs to be | [fex36-67b11](https://data-collections.psdi.ac.uk/records/fex36-67b11) |
+| CGCNN | whether a material is a metal | [ptc95-vbq12](https://data-collections.psdi.ac.uk/records/ptc95-vbq12) |
 
-Their deposit definitions are under `deposits/` and are the concrete examples
-to copy. The artifacts themselves stay in ignored local storage.
+Both were reviewed and accepted by the PSDI Data to Knowledge community. Their
+deposit definitions are in `deposits/`, and are the examples to copy when you
+publish your own.
 
 ## Where to go
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,13 +23,20 @@ uv sync
 `uv sync` installs Goldilocks ML and its required dependencies into a local
 `.venv` managed by `uv`.
 
-## Check the installation
-
-Both command-line tools should display their help:
+## Check it worked
 
 ```bash
-uv run goldilocks-ml train --help
-uv run goldilocks-ml publish --help
+uv run goldilocks-ml --help
+```
+
+You should see the two things this tool does: `train` and `publish`.
+
+Training the real scientific models needs a larger set of libraries — PyTorch
+and pymatgen among them — which are not installed by default because they are
+slow to install and most people do not need them straight away:
+
+```bash
+uv sync --extra qrf95
 ```
 
 Continue with [Train a model](training/index.md) or

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,23 +1,29 @@
 # Publish a model
 
-This guide is for a colleague publishing a new Goldilocks model release to the
-PSDI Data to Knowledge community.
+Publishing puts your trained model in [PSDI Data
+Collections](https://data-collections.psdi.ac.uk) with a permanent identifier
+and a page describing it. People can then cite it, download it, and check they
+have the same file you published.
 
-## What the CLI will and will not do
+This walks through the whole path, from the files you write to a record
+awaiting review.
 
-These hold for every command on this page, so that a mistake costs you a draft
-rather than a published record:
+## Nothing happens by accident
 
-- upload goes directly to PSDI, and only after metadata, file size, and SHA-256
-  validation succeeds;
-- a draft is created but never submitted for review — a person does that in the
-  PSDI web interface, having looked at it;
-- upload happens only with an explicit `--confirm-upload`;
-- a token is read from a file with mode `600` or stricter, and is never
-  printed;
-- a failed metadata, file, or community-binding step removes the partial draft.
+Uploading to a shared production service deserves care, so the tool is built so
+that a mistake costs you a draft rather than a published record:
 
-No model binary and no API token is committed to this repository.
+- everything is checked locally — the description, the file sizes, the
+  checksums — before anything is sent;
+- a draft is created, never submitted; **you** submit it on the PSDI website,
+  after looking at how it turned out;
+- uploading needs an explicit `--confirm-upload`, so it cannot happen from a
+  mistyped command;
+- your token is read from a file only you can read, and is never printed;
+- if any step fails partway, the half-made draft is deleted rather than left
+  lying around.
+
+Neither the model file nor your token is ever committed to this repository.
 
 ## 1. Prerequisites
 

--- a/docs/training/index.md
+++ b/docs/training/index.md
@@ -1,50 +1,69 @@
 # Train a model
 
-A training protocol in this repository is executable, not a README. You bring a
-dataset in the documented layout, run one command, and get a self-describing run
-bundle recording what data was used, how it was split, what was fitted, and how
-it scored.
+You describe a training job in a small configuration file, then run it. The
+file says which data to use, how to split it, which model to fit, and how to
+score it. Everything the run did is written down, so you can repeat it later or
+hand it to someone else.
 
-Complete the [installation](../installation.md) before running these commands.
+Finish the [installation](../installation.md) first.
 
-## Try the complete workflow
+## Run one now
 
-The repository includes pinned synthetic regression and classification
-snapshots. They exercise the installed package, not test-only substitutes:
+The repository ships a small dataset so you can see the whole thing work before
+preparing any of your own.
 
 ```bash
-uv run goldilocks-ml train validate protocols/synthetic/regression.toml \
-  --dataset tests/fixtures/kdist
 uv run goldilocks-ml train run protocols/synthetic/regression.toml \
-  --dataset tests/fixtures/kdist --output local_runs/synthetic-regression
+  --dataset tests/fixtures/kdist --output local_runs/first
 ```
 
-The reference linear and logistic trainers make the shared contract executable
-on any CPU. The [QRF95 protocol](kmesh/qrf95.md) adds scientific k-distance
-quantile training through an optional dependency set. CGCNN training is not
-implemented yet.
+Open `local_runs/first`. You get the predictions next to the true values, the
+split that was used, the scores, and a record of every file involved. Compare
+`model` and `baseline` in the metrics: the baseline just predicts the training
+median, so anything that cannot beat it has not learned.
 
-## The workflow
+## Then use your own data
+
+Three commands, in order.
+
+**Describe your dataset once.** `seal` records what your data is and takes a
+checksum of every file, so a later run can tell whether anything changed
+underneath it.
 
 ```bash
-# 1. Convert your data, then record a digest for every file.
 uv run goldilocks-ml train seal snapshots/mine \
   --record-id my-data --version v1 \
   --target energy --target-contract my-project.energy.v1 \
   --target-definition "Total energy per atom." --target-units eV/atom
+```
 
-# 2. Check the protocol and your data. Trains nothing, contacts nothing.
+**Check before you commit hours to it.** `validate` reads the configuration and
+your data, checks they agree, and works out the split — without training
+anything or touching the network.
+
+```bash
 uv run goldilocks-ml train validate PROTOCOL --dataset snapshots/mine
+```
 
-# 3. Train, evaluate, and write the bundle.
+**Train.** Every check `validate` ran happens again, and then the model is
+fitted.
+
+```bash
 uv run goldilocks-ml train run PROTOCOL --dataset snapshots/mine \
   --output local_runs/mine-v1
 ```
 
-`validate` checks the protocol, the snapshot's digests and contents, the pinned
-feature dependencies, and the derived split. `run` repeats every one of those
-checks, then trains. There is no notebook-only step.
+## Which models you can train
+
+| Configuration | Fits | Needs |
+| --- | --- | --- |
+| `protocols/synthetic/*.toml` | linear and logistic regression | nothing extra |
+| `protocols/kmesh/qrf95.toml` | a k-point distance model with uncertainty | `--extra qrf95` |
+
+The synthetic ones run anywhere and are the fastest way to see the shape of a
+run. [QRF95](kmesh/qrf95.md) is the real thing, and needs the scientific
+libraries the optional dependency set installs.
 
 [Prepare your data](your-data.md){ .md-button .md-button--primary }
-[Protocol reference](protocol.md){ .md-button }
+[Configuration reference](protocol.md){ .md-button }
 [Train QRF95](kmesh/qrf95.md){ .md-button }

--- a/docs/training/kmesh/qrf95.md
+++ b/docs/training/kmesh/qrf95.md
@@ -1,15 +1,22 @@
 # Train QRF95
 
-QRF95 recommends a k-point mesh indirectly. It predicts three quantiles of a
-scalar k-distance in Å⁻¹. The runtime predictor calibrates them and publishes
-the median as the value, keeping the interval as recorded provenance;
-Goldilocks Core converts that value into an explicit mesh. It is not a discrete
-k-index model.
+QRF95 answers "how dense does this k-point mesh need to be" — but not as a grid.
+It predicts a **k-distance**: the largest spacing between neighbouring k-points,
+in Å⁻¹, that still gives a converged answer. Smaller means denser. Goldilocks
+Core turns that one number into an actual `4 4 3` grid using the crystal's
+reciprocal lattice, which is why the model does not have to know anything about
+the shape of the cell.
+
+It predicts three numbers rather than one: a low estimate, a middle one, and a
+high one. The middle one is the recommendation; the outer two say how sure the
+model is, which is worth recording even though nothing downstream acts on them
+today.
 
 ## Install the training dependencies
 
-The scientific feature stack is optional so publication-only installations do
-not pull in Torch and materials libraries:
+Training this model needs PyTorch and several materials libraries. They are not
+installed by default, because someone who only wants to publish a model should
+not have to wait for them:
 
 ```bash
 uv sync --extra qrf95

--- a/docs/training/protocol.md
+++ b/docs/training/protocol.md
@@ -1,9 +1,12 @@
-# Protocol reference
+# Configuration reference
 
-Reviewed protocols live under `protocols/`. Unknown fields are rejected, so a
-protocol cannot quietly carry settings nothing reads.
+Every field a training configuration can contain. The ready-made ones are in
+`protocols/`, and copying the closest is usually easier than starting blank.
 
-## Schema
+A field this file does not list is an error, not something ignored — a typo in
+a setting name stops the run instead of silently changing nothing.
+
+## A complete example
 
 ```toml
 schema_version = 1

--- a/docs/training/your-data.md
+++ b/docs/training/your-data.md
@@ -1,7 +1,8 @@
 # Prepare your data
 
-Convert your data into the layout this project already uses. Nothing here
-converts it for you.
+A training run reads a directory laid out like this. You produce it from
+whatever your calculations already live in — there is no importer, because
+every group's data starts somewhere different.
 
 ```text
 snapshot/
@@ -15,23 +16,31 @@ mp-149,0.2143,Si-diamond
 mp-2534,0.1872,GaAs-zincblende
 ```
 
-## Sample ids must be stable
+## Give each sample a real name
 
-A split derived from row positions changes whenever rows are reordered,
-deduplicated, or filtered, which makes the run irreproducible. Historical
-preprocessing wrote the dataframe index here, so the same material could change
-identity between two runs of the same script.
+The first column identifies the sample, and it has to mean the same thing every
+time. Use whatever your data already calls it: a Materials Project id, an
+internal calculation id, a hash of the structure.
 
-Consecutive integers are therefore rejected. Use a real identifier — the source
-database id is the obvious choice.
+What will not work is a row number. Sort your file differently, drop a
+duplicate, or filter out a failed calculation, and every sample after that
+point silently becomes a different sample — so the split changes, and two runs
+of the same script no longer mean the same thing. Plain `0, 1, 2, ...` is
+rejected for that reason.
 
-## The third column is the group
+## The third column keeps near-duplicates together
 
-It names each sample's group: a structure prototype, a composition, a
-calculation family, whatever your leakage concern is. Group splitting needs it,
-so that highly similar materials cannot straddle a split boundary.
+Materials data is full of samples that are almost the same: polymorphs of one
+composition, the same structure at several volumes, a family of calculations
+that differ in one setting. If some land in training and their near-twins land
+in testing, the test score flatters the model — it has effectively seen the
+answers.
 
-Omit it and the snapshot supports random splitting only.
+The third column is a name you choose for that grouping — a composition, a
+structure prototype, a project code. Everything sharing a name goes into the
+same split, together.
+
+You can leave it out, and then only random splitting is available.
 
 ## Seal the directory
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,8 @@ Remove group and other access:
 chmod 600 "$HOME/.config/goldilocks-ml/psdi.token"
 ```
 
-The CLI intentionally refuses a readable secret file.
+A file anyone on the machine can read is not a safe place for a secret, so
+the tool refuses to use one.
 
 ## `read: not an identifier`
 
@@ -16,21 +17,26 @@ The shell expects a variable name after `read`, not the token itself. Use the
 token setup block in [Publish a model](publishing.md#2-store-the-token-safely).
 The secret is entered only after the prompt appears.
 
-## Token is rejected
+## The token is rejected
 
-Create the token on PSDI. The CLI uses PSDI for all remote operations.
+Tokens come from PSDI Data Collections, and only PSDI tokens work here. If
+yours is from somewhere else, or has expired, create a new one on the PSDI
+website.
 
 ## `upload requires --confirm-upload`
 
-This is a safety check. Confirm that you intend to create a real PSDI draft,
-inspect the command again, then add `--confirm-upload` deliberately.
+Upload creates a real draft on a shared production service, so it does not
+happen by accident. Read the command once more, and if it is what you meant,
+add `--confirm-upload`.
 
 ## Size or SHA-256 mismatch
 
-The artifact is not the byte-identical file described by the manifest. Do not
-edit the digest to silence the error until you determine why the file changed.
-Common causes are retraining, re-serialization, downloading a different model
-version, or using the wrong artifact directory.
+The file on disk is not the one the manifest describes. Usually that means you
+retrained, re-saved the model, downloaded a different version, or pointed
+`--artifact-directory` somewhere else.
+
+Find out which before you touch the digest. Editing it to make the error go
+away is how a published record ends up describing a file nobody has.
 
 Run `goldilocks-ml publish checksum` on the intended final artifact and review the
 corresponding model card and inference requirements before updating the manifest.
@@ -45,8 +51,9 @@ If deletion also fails, the error includes the original upload failure, the
 cleanup failure, and the PSDI draft identifier. Remove that partial draft in the
 PSDI web interface before retrying.
 
-Large artifacts can take several minutes. Do not interrupt the process merely
-because the terminal is quiet.
+A large model can take several minutes to upload with nothing printed in the
+meantime. That silence is normal — interrupting it leaves a partial draft
+behind.
 
 ## Review submission fails
 


### PR DESCRIPTION
The pages read like notes to a colleague who already agreed the problem was worth solving. They opened by defending decisions -- a protocol "is executable, not a README", a model "is not a file someone produced once" -- which argues against a position a newcomer has not taken, using words they have not been given. Snapshot, run bundle, pin, digest, leakage and contract all appeared before they meant anything.

Every page now opens with what the reader came for, and earns its vocabulary as it goes.

The home page starts with the problem in a DFT user's terms -- how dense does the mesh have to be, is this a metal -- rather than with our architecture, and says immediately that anyone who just wants the answers wants Core instead.

"Prepare your data" no longer explains the sample id rule through our own history with a dataframe index. It explains what breaks for the reader: reorder the file, drop a duplicate, and every later sample silently becomes a different sample. The group column is introduced by the problem it solves -- polymorphs of one composition on both sides of a split flatter the score -- before the word for that problem is used at all.

QRF95's page now says what a k-distance is before using it in a sentence about quantiles.

Troubleshooting keeps its shape, keyed by the error you actually saw, with the explanations rewritten to say why rather than to assert that a refusal was intentional.