### PR TITLE
feat(metallicity): serve the classifier as a prediction

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -42,6 +42,43 @@ The directory is what a training run writes: the estimator named in
 [training](training/index.md) and [publishing](publishing.md); the side that
 issues a prediction command is Core.
 
+## A classifier decides; it does not hand over a probability
+
+A model that classifies returns the decision, in the same shape:
+
+```python
+model = load_model(
+    Path("local_runs/cgcnn-v3/model"),
+    artifacts={"atom_init": Path("…/atom_init.json")},
+)
+
+prediction = model.predict(Structure.from_file("Fe.cif"))
+prediction.parameter  # 'metallicity'
+prediction.quantity  # 'is_metal'
+prediction.value  # True
+prediction.details  # {'score': 0.93, 'threshold': 0.0657, 'label': 'metal', …}
+```
+
+The threshold that turned 0.93 into `True` was chosen on the validation split
+and is recorded in `model.json`. It is a fitted parameter like any other, so it
+travels with the model rather than being reinvented by each consumer — and for
+this model it encodes a deliberate asymmetry, that missing a metal costs more
+than an unnecessary dense mesh. See
+[the model page](training/models/metallicity/is_metal-cgcnn.md#the-decision-threshold).
+
+### `confidence` carries a guarantee, not an estimate
+
+The k-distance model sets `confidence` to 0.9, which is a conformal coverage
+level: a proof, under exchangeability, that intervals of that construction
+contain the truth 90% of the time.
+
+The classifier leaves `confidence` empty and puts its score in `details`. The
+score behaves well — on held-out data the structures it scores near 0.8 are
+metallic about 80% of the time — but nothing proves it, and a number that
+merely behaves well should not sit in the field where another model puts a
+guarantee. A consumer comparing the two would be comparing different kinds of
+claim.
+
 ## One prediction type for every parameter
 
 Goldilocks advises more than k-points — smearing, magnetism, spin-orbit,
@@ -49,6 +86,18 @@ pseudopotentials, convergence, exchange-correlation — and each will eventually
 have a model behind it. There is still one `ModelPrediction`. A model names the
 parameter it speaks to and the quantity its number is in; the consumer routes
 on the first and converts on the second.
+
+Not everything predicted is an input file setting. A contract also says which
+`kind` it is:
+
+| Kind | Meaning | Example |
+| --- | --- | --- |
+| `dft_parameter` | written into an input file | `k_distance` → a mesh |
+| `material_property` | a fact about the structure that several settings depend on | `is_metal` |
+
+Metallicity changes both how dense a mesh must be and whether smearing is
+appropriate, so it is predicted once and consumed in more than one place. A
+consumer can tell the two apart without a table of special cases.
 
 That keeps both sides open. A model for a parameter nothing covered before adds
 a row to the contract table here and a resolver on the consumer's side. Neither
@@ -92,6 +141,7 @@ retrained model is a data change and nothing more:
 | `requires_artifacts` | supporting artifacts, pinned by record id and digest |
 | `feature_columns` | the width the estimator must accept |
 | `calibration` | the correction, its coverage, and its mean interval width |
+| `decision` | for a classifier, the threshold and the rule that chose it |
 
 `requires_artifacts` is why a consumer never learns that the k-distance model
 embeds a metallicity checkpoint. The record pins it, `load_model` fetches it
@@ -109,6 +159,7 @@ before any prediction is made.
 | `feature_schema` | upgrade `goldilocks-ml` to load it |
 | `requires_artifacts` | the file is missing, or its digest does not match |
 | `feature_columns` | the artifact and its record disagree |
+| `decision` | a classifier with no threshold cannot produce a label |
 
 The first two are the ones that keep the seam honest as models multiply. The
 third matters most for k-distance specifically: two models can both predict a

--- a/docs/training/models/metallicity/index.md
+++ b/docs/training/models/metallicity/index.md
@@ -14,5 +14,9 @@ decision.
 
 !!! note "Core's side"
 
-    Core has nowhere to put a metallicity answer today. The classifier is
-    consumed only as an input to the k-distance model's features.
+    This package can now serve a metallicity decision through the
+    [inference seam](../../../inference.md). Core has nowhere to put the answer
+    yet: it carries no metallicity field, and its own rule is a heuristic —
+    smearing is applied only when *every* element is metallic, so metallic
+    oxides get none. Tracked in
+    [stfc/goldilocks-core#175](https://github.com/stfc/goldilocks-core/issues/175).

--- a/docs/training/models/metallicity/is_metal-cgcnn.md
+++ b/docs/training/models/metallicity/is_metal-cgcnn.md
@@ -6,6 +6,7 @@
 | Runtime | `metallicity.is_metal.cgcnn` |
 | Target contract | `goldilocks.is_metal.dft_band_gap_zero.v1` |
 | Dataset | `matbench_mp_is_metal`, 106113 structures |
+| Served by | `load_model`, returning a boolean |
 
 A crystal graph convolutional network that answers one question: does DFT give
 this crystal a zero band gap. Metals need denser k-point sampling than
@@ -182,7 +183,10 @@ it produces belongs only to these weights. See
 
 The threshold is chosen on the validation split alone and applied unchanged to
 calibration and test — it is a fitted parameter, so choosing it on test would be
-reading the answer.
+reading the answer. It is written into `model.json` under `decision`, so a
+served model applies the same line rather than leaving each consumer to pick
+one. A record without it is refused at load: a classifier that cannot turn its
+own score into a label is not servable.
 
 The floor is not free. Buying recall costs precision, and the price rises
 steeply; measured on validation:

--- a/src/goldilocks_ml/baselines.py
+++ b/src/goldilocks_ml/baselines.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import math
 from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -135,6 +135,13 @@ class _Logistic(_Linear):
     """Batch gradient-descent logistic regression over standardised features."""
 
     positive_label: str = ""
+    # How this classifier's score becomes a label. Chosen after the fit, on the
+    # validation split, so the run fills it in before the record is written.
+    decision: dict[str, Any] = field(default_factory=dict)
+
+    def with_decision(self, decision: Any) -> _Logistic:
+        """Return a copy carrying the threshold rule the run selected."""
+        return replace(self, decision=dict(decision))
 
     def predict(
         self, samples: Sequence[Sample], features: FeatureMatrix
@@ -155,6 +162,7 @@ class _Logistic(_Linear):
             "trainer": "logistic_regression",
             "task": "classification",
             "positive_label": self.positive_label,
+            "decision": dict(self.decision),
         }
 
 

--- a/src/goldilocks_ml/cli.py
+++ b/src/goldilocks_ml/cli.py
@@ -24,6 +24,7 @@ from goldilocks_ml.evaluation import (
 from goldilocks_ml.hashing import sha256_file
 from goldilocks_ml.protocol import TrainingProtocol, load_protocol
 from goldilocks_ml.registry import (
+    DecidingModel,
     FittedModel,
     QuantileFittedModel,
     TrainingContext,
@@ -395,7 +396,6 @@ def execute(
     # Test samples, labels, and features never reach the trainer.
     model = get_trainer(protocol.trainer)(protocol, context)
     _check_runtime(protocol, model)
-    model.save(directory / "model")
 
     quantiles = (
         tuple(model.quantiles) if isinstance(model, QuantileFittedModel) else None
@@ -407,6 +407,23 @@ def execute(
         predictions, summary = _train_classification(protocol, parts, model, features)
         positive = summary["positive_label"]
         quantiles = None
+        # The threshold is chosen here, after the fit, but it is still a fitted
+        # parameter. A served model that does not carry it cannot turn its own
+        # score into a label, so it goes into the record before the record is
+        # written.
+        if isinstance(model, DecidingModel):
+            model = model.with_decision(
+                {
+                    "threshold": summary["decision_threshold"]["value"],
+                    "metric": summary["decision_threshold"]["metric"],
+                    "min_recall": summary["decision_threshold"]["min_recall"],
+                    "selected_on": summary["decision_threshold"]["selected_on"],
+                    "positive_label": positive,
+                    "negative_label": summary["negative_label"],
+                }
+            )
+
+    model.save(directory / "model")
 
     metrics = {
         "task": protocol.task,

--- a/src/goldilocks_ml/inference.py
+++ b/src/goldilocks_ml/inference.py
@@ -37,6 +37,15 @@ MODEL_RECORD_FILE = "model.json"
 SUPPORTED_RECORD_SCHEMA_VERSIONS = frozenset({1})
 
 
+# What a prediction speaks to. A DFT parameter is written into an input file.
+# A material property is a fact about the structure that informs several inputs
+# -- metallicity changes both mesh density and the smearing choice -- so it is
+# predicted once and consumed in more than one place.
+DFT_PARAMETER = "dft_parameter"
+MATERIAL_PROPERTY = "material_property"
+KINDS = frozenset({DFT_PARAMETER, MATERIAL_PROPERTY})
+
+
 @dataclass(frozen=True, slots=True)
 class ContractSpec:
     """What a published target contract means to a consumer.
@@ -49,8 +58,10 @@ class ContractSpec:
 
     parameter: str
     quantity: str
+    kind: str = "dft_parameter"
     units: str | None = None
     positive: bool = False
+    boolean: bool = False
 
     def check_units(self, units: str | None) -> None:
         """Reject a record whose units are not the ones this contract means."""
@@ -60,9 +71,15 @@ class ContractSpec:
                 f"declares {units!r}"
             )
 
-    def check_value(self, value: float) -> None:
+    def check_value(self, value: Any) -> None:
         """Reject a prediction outside the domain the quantity admits."""
-        if self.positive and not value > 0:
+        if self.boolean:
+            if not isinstance(value, bool):
+                raise ValueError(
+                    f"{self.quantity} must be a boolean; the model predicted {value!r}"
+                )
+            return
+        if self.positive and not float(value) > 0:
             raise ValueError(
                 f"{self.quantity} must be positive; the model predicted {value}"
             )
@@ -75,8 +92,15 @@ CONTRACTS: Mapping[str, ContractSpec] = {
     "goldilocks.k_distance.mesh_lower_bound.2pi.v1": ContractSpec(
         parameter="k_points",
         quantity="k_distance",
+        kind=DFT_PARAMETER,
         units="1/angstrom",
         positive=True,
+    ),
+    "goldilocks.is_metal.dft_band_gap_zero.v1": ContractSpec(
+        parameter="metallicity",
+        quantity="is_metal",
+        kind=MATERIAL_PROPERTY,
+        boolean=True,
     ),
 }
 

--- a/src/goldilocks_ml/models/metallicity/is_metal/cgcnn/predictor.py
+++ b/src/goldilocks_ml/models/metallicity/is_metal/cgcnn/predictor.py
@@ -1,0 +1,171 @@
+"""Serve the metallicity classifier for single structures.
+
+The serving counterpart of this package's :mod:`trainer`. A classifier returns
+a score; the label it becomes depends on a threshold chosen on the validation
+split, so the record carries that threshold and this module applies it. A
+consumer receives the decision, not the number behind it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from goldilocks_ml.hashing import sha256_file
+from goldilocks_ml.inference import ModelPrediction, contract_for
+from goldilocks_ml.models.metallicity.is_metal.cgcnn.trainer import (
+    RUNTIME,
+    RUNTIME_VERSION,
+)
+from goldilocks_ml.registry import register_predictor
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
+
+ATOM_INIT = "atom_init"
+
+
+@dataclass(frozen=True, slots=True)
+class MetallicityPredictor:
+    """A fitted metallicity classifier, loaded for prediction from structures."""
+
+    model: Any
+    record: Mapping[str, Any]
+    atom_init: Path
+    model_id: str
+
+    def predict(self, structure: Structure) -> ModelPrediction:
+        """Return whether one structure is metallic."""
+        return self.predict_batch([structure])[0]
+
+    def predict_batch(self, structures: Sequence[Structure]) -> list[ModelPrediction]:
+        """Return one decision per structure, graphing them together."""
+        from goldilocks_ml.models.k_points.k_distance.qrf.embedding import build_graph
+        from goldilocks_ml.models.metallicity.is_metal.cgcnn.trainer import class_scores
+
+        if not structures:
+            return []
+
+        graphs = [build_graph(structure, self.atom_init) for structure in structures]
+        scores = class_scores(self.model, graphs)
+
+        decision = self.record["decision"]
+        threshold = float(decision["threshold"])
+        target_contract = self.record["target"]["contract"]
+        contract = contract_for(target_contract)
+        classes = self.record["classes"]
+
+        predictions = []
+        for score in scores:
+            is_positive = score >= threshold
+            predictions.append(
+                ModelPrediction(
+                    parameter=contract.parameter,
+                    quantity=contract.quantity,
+                    value=is_positive,
+                    target_contract=target_contract,
+                    model_id=self.model_id,
+                    # `confidence` carries a guarantee, and this score is not
+                    # one. It measures well on held-out data but nothing proves
+                    # it, unlike a conformal coverage level, so it travels as
+                    # provenance instead of as a claim.
+                    confidence=None,
+                    details={
+                        "score": score,
+                        "threshold": threshold,
+                        "label": classes["positive"]
+                        if is_positive
+                        else classes["negative"],
+                        "score_is": "uncalibrated positive-class softmax",
+                        "threshold_selected_on": decision.get("selected_on"),
+                        "threshold_metric": decision.get("metric"),
+                        "min_recall": decision.get("min_recall"),
+                    },
+                )
+            )
+        for prediction in predictions:
+            contract.check_value(prediction.value)
+        return predictions
+
+
+def load(
+    record: Mapping[str, Any], directory: Path, artifacts: Mapping[str, Path]
+) -> MetallicityPredictor:
+    """Build a predictor from a stored record, checking what it declares."""
+    import torch
+
+    from goldilocks_ml.models.k_points.k_distance.qrf.embedding import CGCNN
+    from goldilocks_ml.models.metallicity.is_metal.cgcnn import graphs as crystal_graphs
+
+    version = record.get("runtime", {}).get("version")
+    if version != RUNTIME_VERSION:
+        raise ValueError(
+            f"this artifact declares {RUNTIME} runtime version {version!r}; "
+            f"this build implements version {RUNTIME_VERSION}"
+        )
+
+    schema = record["feature_schema"]
+    if schema != crystal_graphs.SCHEMA:
+        raise ValueError(
+            f"this artifact was built against feature contract {schema!r}, but "
+            f"the installed goldilocks-ml provides {crystal_graphs.SCHEMA!r}; "
+            "upgrade goldilocks-ml to load it"
+        )
+
+    decision = record.get("decision") or {}
+    if "threshold" not in decision:
+        raise ValueError(
+            "this artifact records no decision threshold, so its score cannot "
+            "be turned into a label; it predates the threshold being written "
+            "into the record and must be retrained or repaired"
+        )
+
+    if ATOM_INIT not in artifacts:
+        raise ValueError(f"the {schema} feature contract needs artifact: {ATOM_INIT}")
+    atom_init = Path(artifacts[ATOM_INIT])
+    # The embedding table is part of the feature definition: a different table
+    # produces different graphs and therefore different answers, silently.
+    pinned_table = record.get("atom_init_sha256")
+    if pinned_table:
+        digest = sha256_file(atom_init)
+        if digest != pinned_table:
+            raise ValueError(
+                f"{atom_init.name} has SHA-256 {digest}; its record pins {pinned_table}"
+            )
+
+    weights_file = record["artifacts"]["estimator"]
+    weights_path = Path(directory) / weights_file
+    pinned = record["artifacts"].get("estimator_sha256")
+    if not pinned:
+        raise ValueError(
+            f"the record does not pin a SHA-256 for {weights_file}; refusing to "
+            "load unverified weights"
+        )
+    digest = sha256_file(weights_path)
+    if digest != pinned:
+        raise ValueError(
+            f"{weights_file} has SHA-256 {digest}; its record pins {pinned}"
+        )
+
+    stored = torch.load(weights_path, map_location="cpu", weights_only=True)
+    architecture = dict(record["architecture"])
+    if dict(stored["architecture"]) != architecture:
+        raise ValueError(
+            f"{weights_file} was built with a different architecture than its "
+            "record declares; the artifact and its record disagree"
+        )
+    model = CGCNN(**architecture)
+    model.load_state_dict(stored["state_dict"])
+    model.eval()
+
+    return MetallicityPredictor(
+        model=model,
+        record=record,
+        atom_init=atom_init,
+        model_id=f"{RUNTIME}@{schema}",
+    )
+
+
+register_predictor(RUNTIME, load)

--- a/src/goldilocks_ml/models/metallicity/is_metal/cgcnn/trainer.py
+++ b/src/goldilocks_ml/models/metallicity/is_metal/cgcnn/trainer.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -71,6 +71,9 @@ class CGCNNClassifier:
     hyperparameters: dict[str, Any]
     training: dict[str, Any]
     atom_init: Path = field(compare=False, default=Path())
+    # Filled in after the fit, when the run has chosen a threshold on the
+    # validation split. Empty until then, and an unserved model may stay empty.
+    decision: dict[str, Any] = field(default_factory=dict)
 
     def _model(self) -> CGCNN:
         model = CGCNN(**self.architecture)
@@ -85,7 +88,11 @@ class CGCNNClassifier:
         del features  # a graph model reads structures, not a feature row
         if not samples:
             return []
-        return _scores(self._model(), graphs_for(samples, self.atom_init))
+        return class_scores(self._model(), graphs_for(samples, self.atom_init))
+
+    def with_decision(self, decision: Any) -> CGCNNClassifier:
+        """Return a copy carrying the threshold rule the run selected."""
+        return replace(self, decision=dict(decision))
 
     def describe(self) -> dict[str, Any]:
         """Return the JSON record a predictor reads this model back through."""
@@ -105,6 +112,9 @@ class CGCNNClassifier:
                 "positive": self.positive_label,
                 "negative": self.negative_label,
             },
+            # How this model's score becomes a label. Without it the artifact
+            # predicts a number and nothing can act on it.
+            "decision": dict(self.decision),
             "target": {
                 "name": self.target_name,
                 "contract": self.target_contract,
@@ -133,7 +143,7 @@ class CGCNNClassifier:
         )
 
 
-def _scores(
+def class_scores(
     model: CGCNN,
     graphs: Sequence[Data],
     batch_size: int = 256,

--- a/src/goldilocks_ml/registry.py
+++ b/src/goldilocks_ml/registry.py
@@ -111,6 +111,21 @@ class QuantileFittedModel(FittedModel, Protocol):
         ...
 
 
+@runtime_checkable
+class DecidingModel(FittedModel, Protocol):
+    """A classifier whose serving threshold is chosen after the fit.
+
+    Threshold selection reads the validation split and is the same procedure for
+    every classifier, so it lives in the run rather than in a trainer. The
+    chosen threshold is still a fitted parameter, and a served model that does
+    not carry it cannot turn its own score into a label.
+    """
+
+    def with_decision(self, decision: Mapping[str, Any]) -> DecidingModel:
+        """Return a copy whose record carries the decision rule applied to it."""
+        ...
+
+
 # Feature extraction must be stateless across samples. Any fitted preprocessing
 # belongs inside the trainer, where split boundaries are explicit.
 Trainer = Callable[["TrainingProtocol", TrainingContext], FittedModel]
@@ -125,17 +140,18 @@ Predictor = Callable[[Mapping[str, Any], Path, Mapping[str, Path]], "StructureMo
 _TRAINERS: dict[str, Trainer] = {}
 _FEATURES: dict[str, FeatureContract] = {}
 _PREDICTORS: dict[str, Predictor] = {}
+_QRF = "goldilocks_ml.models.k_points.k_distance.qrf"
+_CGCNN = "goldilocks_ml.models.metallicity.is_metal.cgcnn"
 _BUILTIN_TRAINERS = {
-    "quantile_random_forest": "goldilocks_ml.models.k_points.k_distance.qrf.trainer",
-    "cgcnn_classifier": "goldilocks_ml.models.metallicity.is_metal.cgcnn.trainer",
+    "quantile_random_forest": f"{_QRF}.trainer",
+    "cgcnn_classifier": f"{_CGCNN}.trainer",
 }
 # Keyed by serving runtime, not by trainer: one fitting algorithm can produce
 # models that must be read back differently.
 _BUILTIN_PREDICTORS = {
-    "k_points.k_distance.qrf": "goldilocks_ml.models.k_points.k_distance.qrf.predictor",
+    "k_points.k_distance.qrf": f"{_QRF}.predictor",
+    "metallicity.is_metal.cgcnn": f"{_CGCNN}.predictor",
 }
-_QRF = "goldilocks_ml.models.k_points.k_distance.qrf"
-_CGCNN = "goldilocks_ml.models.metallicity.is_metal.cgcnn"
 _BUILTIN_FEATURES = {
     "comp_struct_soap_lattice_metal.v1": f"{_QRF}.features",
     "crystal_graph.v1": f"{_CGCNN}.graphs",

--- a/tests/test_cgcnn.py
+++ b/tests/test_cgcnn.py
@@ -214,3 +214,128 @@ def test_an_explicit_device_is_honoured() -> None:
     """The parameter must decide the device, not merely be accepted."""
     assert resolve_device("cpu") == torch.device("cpu")
     assert resolve_device("auto").type in {"cpu", "mps", "cuda"}
+
+
+def fitted_classifier(atom_init: Path, **overrides: Any) -> Any:
+    """An untrained classifier of the shipped shape, for round-trip tests."""
+    from goldilocks_ml.hashing import sha256_file
+    from goldilocks_ml.models.k_points.k_distance.qrf.embedding import CGCNN
+    from goldilocks_ml.models.metallicity.is_metal.cgcnn.trainer import CGCNNClassifier
+
+    torch.manual_seed(0)
+    fields: dict[str, Any] = {
+        "state_dict": CGCNN(**ARCHITECTURE).state_dict(),
+        "architecture": dict(ARCHITECTURE),
+        "atom_init_digest": sha256_file(atom_init),
+        "positive_label": "metal",
+        "negative_label": "insulator",
+        "seed": 42,
+        "target_name": "is_metal",
+        "target_contract": "goldilocks.is_metal.dft_band_gap_zero.v1",
+        "feature_schema": crystal_graphs.SCHEMA,
+        "requires_artifacts": (),
+        "hyperparameters": {},
+        "training": {},
+        "atom_init": atom_init,
+    }
+    fields.update(overrides)
+    return CGCNNClassifier(**fields)
+
+
+def saved_model(tmp_path: Path, **overrides: Any) -> tuple[Path, Path]:
+    """Write a classifier carrying a decision, and return its directory."""
+    atom_init = atom_table(tmp_path)
+    model = fitted_classifier(atom_init, **overrides)
+    if "decision" not in overrides:
+        model = model.with_decision(
+            {
+                "threshold": 0.5,
+                "metric": "mcc",
+                "min_recall": 0.97,
+                "selected_on": "validation",
+                "positive_label": "metal",
+                "negative_label": "insulator",
+            }
+        )
+    directory = tmp_path / "model"
+    directory.mkdir()
+    model.save(directory)
+    return directory, atom_init
+
+
+def a_structure() -> Structure:
+    return Structure(Lattice.cubic(5.43), ["Si", "Si"], [[0, 0, 0], [0.25, 0.25, 0.25]])
+
+
+def test_a_served_classifier_decides_rather_than_scoring(tmp_path: Path) -> None:
+    from goldilocks_ml.inference import load_model
+
+    directory, atom_init = saved_model(tmp_path)
+
+    model = load_model(directory, artifacts={"atom_init": atom_init})
+    prediction = model.predict(a_structure())
+
+    assert isinstance(prediction.value, bool)
+    assert prediction.parameter == "metallicity"
+    assert prediction.quantity == "is_metal"
+    assert prediction.target_contract == "goldilocks.is_metal.dft_band_gap_zero.v1"
+    # The score is provenance, not a claim: `confidence` carries guarantees.
+    assert prediction.confidence is None
+    assert 0.0 <= prediction.details["score"] <= 1.0
+    assert prediction.details["threshold"] == 0.5
+    assert prediction.details["label"] in {"metal", "insulator"}
+    assert (prediction.details["label"] == "metal") is prediction.value
+
+
+def test_a_batch_decides_once_per_structure(tmp_path: Path) -> None:
+    from goldilocks_ml.inference import load_model
+
+    directory, atom_init = saved_model(tmp_path)
+    model = load_model(directory, artifacts={"atom_init": atom_init})
+
+    predictions = model.predict_batch([a_structure(), a_structure()])
+
+    assert len(predictions) == 2
+    assert predictions[0].details["score"] == predictions[1].details["score"]
+    assert model.predict_batch([]) == []
+
+
+def test_a_record_without_a_threshold_cannot_be_served(tmp_path: Path) -> None:
+    from goldilocks_ml.inference import load_model
+
+    directory, atom_init = saved_model(tmp_path, decision={})
+
+    with pytest.raises(ValueError, match="records no decision threshold"):
+        load_model(directory, artifacts={"atom_init": atom_init})
+
+
+def test_substituted_weights_are_refused(tmp_path: Path) -> None:
+    from goldilocks_ml.inference import load_model
+
+    directory, atom_init = saved_model(tmp_path)
+    weights = directory / "is_metal.pt"
+    weights.write_bytes(weights.read_bytes() + b"\x00")
+
+    with pytest.raises(ValueError, match="its record pins"):
+        load_model(directory, artifacts={"atom_init": atom_init})
+
+
+def test_a_substituted_atom_table_is_refused(tmp_path: Path) -> None:
+    from goldilocks_ml.inference import load_model
+
+    directory, atom_init = saved_model(tmp_path)
+    atom_init.write_text(
+        json.dumps({key: [0.2] * 92 for key in ATOM_TABLE}), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="its record pins"):
+        load_model(directory, artifacts={"atom_init": atom_init})
+
+
+def test_the_atom_table_must_be_supplied(tmp_path: Path) -> None:
+    from goldilocks_ml.inference import load_model
+
+    directory, _ = saved_model(tmp_path)
+
+    with pytest.raises(ValueError, match="needs artifact"):
+        load_model(directory, artifacts={})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -512,6 +512,43 @@ def test_a_reference_trainer_declares_no_runtime_and_is_exempt(
     _check_runtime(protocol, _Stub({"trainer": "linear_regression"}))
 
 
+def test_the_chosen_threshold_lands_in_the_model_record(
+    tmp_path: Path, snapshot_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    protocol = _setup(
+        tmp_path,
+        snapshot_dir,
+        classification=True,
+        evaluation={
+            "metrics": ["accuracy", "recall", "mcc"],
+            "threshold_metric": "mcc",
+            "min_recall": 0.5,
+        },
+    )
+    output = tmp_path / "run-1"
+
+    _run(
+        monkeypatch,
+        "run",
+        str(protocol),
+        "--dataset",
+        str(snapshot_dir),
+        "--output",
+        str(output),
+    )
+
+    record = json.loads((output / "model" / "model.json").read_text())
+    metrics = json.loads((output / "metrics.json").read_text())
+    decision = record["decision"]
+    # The served record must be able to turn its own score into a label
+    # without the run bundle that produced it.
+    assert decision["threshold"] == metrics["decision_threshold"]["value"]
+    assert decision["metric"] == "mcc"
+    assert decision["min_recall"] == 0.5
+    assert decision["selected_on"] == "validation"
+    assert decision["positive_label"] == metrics["positive_label"]
+
+
 def test_threshold_selection_requires_a_validation_split(
     tmp_path: Path, snapshot_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -355,3 +355,34 @@ def test_every_contract_names_a_parameter_and_a_quantity() -> None:
     for name in inference.CONTRACTS:
         contract = contract_for(name)
         assert contract.parameter and contract.quantity
+
+
+def test_contracts_say_what_kind_of_advice_they_carry() -> None:
+    from goldilocks_ml.inference import (
+        DFT_PARAMETER,
+        KINDS,
+        MATERIAL_PROPERTY,
+        contract_for,
+    )
+
+    mesh = contract_for("goldilocks.k_distance.mesh_lower_bound.2pi.v1")
+    metal = contract_for("goldilocks.is_metal.dft_band_gap_zero.v1")
+
+    # A k-distance is written into an input file; metallicity is a fact about
+    # the material that several inputs depend on.
+    assert mesh.kind == DFT_PARAMETER
+    assert metal.kind == MATERIAL_PROPERTY
+    assert {mesh.kind, metal.kind} <= KINDS
+    assert metal.parameter == "metallicity"
+    assert metal.quantity == "is_metal"
+
+
+def test_a_boolean_quantity_refuses_a_number() -> None:
+    from goldilocks_ml.inference import contract_for
+
+    contract = contract_for("goldilocks.is_metal.dft_band_gap_zero.v1")
+
+    contract.check_value(True)
+    contract.check_value(False)
+    with pytest.raises(ValueError, match="must be a boolean"):
+        contract.check_value(0.87)


### PR DESCRIPTION
Closes #15.

There was a metallicity classifier in this package and no way to ask it
anything. This adds the predictor, registers the runtime, and puts the target
contract in the table Core routes on.

```python
prediction = model.predict(Structure.from_file("Fe.cif"))
prediction.parameter  # 'metallicity'
prediction.quantity   # 'is_metal'
prediction.value      # True
prediction.details    # {'score': 0.93, 'threshold': 0.0657, 'label': 'metal', …}
```

## The blocker was that the threshold was not in the record

A classifier returns a score. Turning it into a label needs a threshold, and
that threshold was written only into `metrics.json` — a run artifact, not the
model directory. **A published model could not turn its own score into a
label.**

The cause is an asymmetry worth naming. The QRF's conformal correction is
fitted inside its trainer, which holds the calibration split. A decision
threshold is chosen by the run, on validation, because the procedure is the
same for every classifier and does not belong to any one of them. So it never
reached the record.

`DecidingModel` closes it: an optional protocol, in the shape of the existing
`QuantileFittedModel`, letting the run hand the chosen threshold back before
the record is written. `model.save()` moves after the evaluation branch for
the same reason. A record with no threshold is **refused at load**, rather than
silently defaulting to 0.5 — a default here would quietly discard the recall
floor the protocol argued for.

## Decisions, not probabilities

`value` is a boolean, matching the point-value rule the seam already follows
where the k-distance model publishes a median and demotes its interval to
`details`.

`confidence` stays empty, and this is the one judgement call worth reviewing.
The k-distance model puts 0.9 there — a conformal coverage level, which is a
guarantee. A softmax is not. I checked ours rather than assuming: on the
calibration split it tracks observed frequency closely (scores in 0.8–0.9 are
84% metallic, 0.1–0.2 are 17%), so it is not *untrustworthy*. But behaving well
and being proven are different claims, and a consumer comparing the two fields
would be comparing different things. The rule this sets is **`confidence`
carries a guarantee; estimates go in `details`.**

A side effect: probability calibration (Platt, isotonic) would buy little here,
so it drops down the list rather than up it.

## `kind`

Contracts now declare whether they carry a `dft_parameter` — written into an
input file — or a `material_property`, a fact several settings depend on.
Metallicity is the first of the second sort: it changes both mesh density and
whether smearing applies. This is the structure agreed when the model tree was
laid out, implemented where it is used rather than declared ahead of it.

## Review notes

- `_Logistic` gains a `decision` too. It is not served, but a classifier's
  record should say how its score becomes a label regardless.
- `local_runs/cgcnn-v3` — the release run — **cannot be loaded by this branch**,
  because it was trained before the threshold went into the record. It fails
  with the intended message. Serving it needs a retrain, or the same repair
  #21 will need for the published records.
- Base install still imports `goldilocks_ml.inference` with the model stack
  blocked; verified locally as well as in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
