### PR TITLE
docs(nav): put each notebook under the model it belongs to

### DIFF
--- a/docs/training/models/k_points/k_distance-qrf.md
+++ b/docs/training/models/k_points/k_distance-qrf.md
@@ -6,7 +6,7 @@
 | Runtime | `k_points.k_distance.qrf` |
 | Target contract | `goldilocks.k_distance.mesh_lower_bound.2pi.v1` |
 | Dataset | `goldilocks-kdist-ultra`, 21053 structures |
-| Try it | [notebook](../../../notebooks/k_distance-qrf.ipynb) |
+| Notebook | [run it yourself](../../../notebooks/k_distance-qrf.ipynb) |
 
 QRF95 answers "how dense does this k-point mesh need to be" — but not as a grid.
 It predicts a **k-distance**: the largest spacing between neighbouring k-points,

--- a/docs/training/models/metallicity/is_metal-cgcnn.md
+++ b/docs/training/models/metallicity/is_metal-cgcnn.md
@@ -7,7 +7,7 @@
 | Target contract | `goldilocks.is_metal.dft_band_gap_zero.v1` |
 | Dataset | `matbench_mp_is_metal`, 106113 structures |
 | Served by | `load_model`, returning a boolean |
-| Try it | [notebook](../../../notebooks/metallicity-cgcnn.ipynb) |
+| Notebook | [run it yourself](../../../notebooks/metallicity-cgcnn.ipynb) |
 | Deposit | `deposits/metallicity/is_metal/cgcnn/`, prepared |
 
 A crystal graph convolutional network that answers one question: does DFT give

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,12 +59,14 @@ nav:
           - Overview: training/models/index.md
           - k-point mesh:
               - Overview: training/models/k_points/index.md
-              - k-distance / QRF: training/models/k_points/k_distance-qrf.md
-              - Try it (notebook): notebooks/k_distance-qrf.ipynb
+              - k-distance / QRF:
+                  - Training: training/models/k_points/k_distance-qrf.md
+                  - Notebook: notebooks/k_distance-qrf.ipynb
           - Metallicity:
               - Overview: training/models/metallicity/index.md
-              - is-metal / CGCNN: training/models/metallicity/is_metal-cgcnn.md
-              - Try it (notebook): notebooks/metallicity-cgcnn.ipynb
+              - is-metal / CGCNN:
+                  - Training: training/models/metallicity/is_metal-cgcnn.md
+                  - Notebook: notebooks/metallicity-cgcnn.ipynb
               - Representation / CGCNN: training/models/metallicity/representation-cgcnn.md
           - Magnetism: training/models/magnetism/index.md
           - Hubbard U: training/models/hubbard_u/index.md


### PR DESCRIPTION
The notebooks sat beside the model pages rather than under them, which read as if they were separate models. Each model now owns two pages: how it was trained, and a notebook that runs it.

```
Models
├── k-point mesh
│   └── k-distance / QRF
│       ├── Training
│       └── Notebook
└── Metallicity
    ├── is-metal / CGCNN
    │   ├── Training
    │   └── Notebook
    └── Representation / CGCNN
```

`Notebook` rather than `Jupyter notebook`: the entry sits inside the model's own section, so it only has to say what kind of page it is, and the rendered page already carries Jupyter's own chrome and the `.ipynb` download.

The header table on both model pages said `Try it | notebook`; it now matches the nav.

`mkdocs build --strict` is clean.