### PR TITLE
docs(readme): show build, docs and licence status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # goldilocks-ml
 
+[![Build Status][ci-badge]][ci-link]
+[![Docs status][docs-badge]][docs-link]
+[![License][license-badge]][license-link]
+
 Offline model development, evaluation, and artifact publication for Goldilocks.
 
 The repository owns model release provenance: model cards, PSDI metadata,
@@ -89,3 +93,10 @@ Two modules under `src/goldilocks_ml/models/` are adapted from
 `stfc/goldilocks_kpoints`, which is CC BY 4.0, and carry attribution in their
 headers. CC BY 4.0 permits adapted material under other terms provided
 attribution is kept, so they are redistributed under the licence above.
+
+[ci-badge]: https://github.com/stfc/goldilocks-ml/actions/workflows/ci.yml/badge.svg?branch=main
+[ci-link]: https://github.com/stfc/goldilocks-ml/actions
+[docs-badge]: https://img.shields.io/github/actions/workflow/status/stfc/goldilocks-ml/docs.yml?branch=main&label=docs
+[docs-link]: https://stfc.github.io/goldilocks-ml/
+[license-badge]: https://img.shields.io/badge/License-BSD_3--Clause-blue.svg
+[license-link]: https://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
The first three badges from #31 — the ones that are true today.

```markdown
[![Build Status][ci-badge]][ci-link]
[![Docs status][docs-badge]][docs-link]
[![License][license-badge]][license-link]
```

Reference-style links at the bottom of the file, the way janus-core does it, so the top of the README stays readable as text.

Each URL was fetched before committing; all three render real status rather than "no status" or "not found":

| Badge | Renders |
| --- | --- |
| CI | `passing` |
| Docs | `passing` |
| License | `BSD 3-Clause` |

The other four stay in #31: PyPI and Python versions are blocked on #12, coverage needs a measurement step and an external service, and the DOI needs the repository registered with Zenodo.

Closes nothing — #31 stays open for the remaining four.