### PR TITLE
docs(deposits): index the representation record for what it is

### DIFF
--- a/deposits/metallicity/representation/cgcnn/metadata.json
+++ b/deposits/metallicity/representation/cgcnn/metadata.json
@@ -174,10 +174,13 @@
         "subject": "Materials science"
       },
       {
-        "subject": "Metallicity classification"
+        "subject": "Representation learning"
       },
       {
         "subject": "Graph neural networks"
+      },
+      {
+        "subject": "Feature extraction"
       }
     ],
     "publisher": "PSDI",


### PR DESCRIPTION
The v2.0 description was already rewritten for the retitle. Its `subjects` were not, and still read *Metallicity classification* — which is what people search PSDI on, and the one claim the retitle exists to withdraw.

```
- Materials science, Metallicity classification, Graph neural networks
+ Materials science, Representation learning, Graph neural networks, Feature extraction
```

`publish validate` passes.

## Still open before this record can be published

The last paragraph of the description points readers at "the Goldilocks CGCNN metallicity classifier trained on Matbench `mp_is_metal`" by name, with no record id — because that record is still a draft. Once it is published, the id should go in.

That reverses the publication order I suggested earlier: the classifier should go first, so its id can be named here.