### PR TITLE
fix(docs): a workstation path, a broken Colab button, and a page that was hard to read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,16 @@ jobs:
       - name: Test
         run: uv run --frozen pytest
 
+      # A notebook is committed with its outputs, so anything the machine that
+      # ran it printed ships to the public site. A home directory is the one
+      # that gets there by accident.
+      - name: Refuse a workstation path in the documentation
+        run: |
+          if grep -rIn -e '/Users/' -e '/home/' docs/; then
+            echo "::error::a local path reached docs/; clear the cell output that carries it"
+            exit 1
+          fi
+
   # A base install must stay light and must still train. Both halves of that
   # promise break silently -- one stray module-level import in the CLI pulls in
   # the scientific stack, and the unit suite would not notice because it runs

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -64,7 +64,7 @@ and is recorded in `model.json`. It is a fitted parameter like any other, so it
 travels with the model rather than being reinvented by each consumer — and for
 this model it encodes a deliberate asymmetry, that missing a metal costs more
 than an unnecessary dense mesh. See
-[the model page](training/models/metallicity/is_metal-cgcnn.md#the-decision-threshold).
+[the model page](training/models/metallicity/is_metal-cgcnn.md#where-the-line-is-drawn).
 
 ### `confidence` carries a guarantee, not an estimate
 

--- a/docs/notebooks/k_distance-qrf.ipynb
+++ b/docs/notebooks/k_distance-qrf.ipynb
@@ -7,8 +7,6 @@
    "source": [
     "# What k-point mesh does this crystal need?\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/goldilocks-ml/blob/main/docs/notebooks/k_distance-qrf.ipynb)\n",
-    "\n",
     "`k_points.k_distance.qrf` — the quantile random forest published as\n",
     "[fex36-67b11](https://data-collections.psdi.ac.uk/records/fex36-67b11).\n",
     "\n",
@@ -143,14 +141,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/junwenyin/Library/CloudStorage/OneDrive-ScienceandTechnologyFacilitiesCouncil/2-research/1-goldilocks/3-goldilocks-ml/.venv/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",

--- a/docs/notebooks/metallicity-cgcnn.ipynb
+++ b/docs/notebooks/metallicity-cgcnn.ipynb
@@ -7,8 +7,6 @@
    "source": [
     "# Is this crystal a metal?\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/goldilocks-ml/blob/main/docs/notebooks/metallicity-cgcnn.ipynb)\n",
-    "\n",
     "`metallicity.is_metal.cgcnn` — a crystal graph network that answers one\n",
     "question: does DFT give this crystal a zero band gap.\n",
     "\n",
@@ -33,7 +31,9 @@
     "\n",
     "The table comes from the published PSDI record. It is part of the model, not a\n",
     "detail — swap it and the graphs change, so the answers change, silently. That\n",
-    "is why its checksum is pinned in the model's record and checked on load."
+    "is why its checksum is pinned in the model's record and checked on load.\n",
+    "\n",
+    "Run this from a clone of the repository. The weights are not published yet, so they are copied from `local_data/`; when the record goes live they will download like the table does.\n"
    ]
   },
   {
@@ -100,14 +100,6 @@
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/junwenyin/Library/CloudStorage/OneDrive-ScienceandTechnologyFacilitiesCouncil/2-research/1-goldilocks/3-goldilocks-ml/.venv/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",

--- a/docs/training/models/metallicity/is_metal-cgcnn.md
+++ b/docs/training/models/metallicity/is_metal-cgcnn.md
@@ -10,87 +10,105 @@
 | Notebook | [run it yourself](../../../notebooks/metallicity-cgcnn.ipynb) |
 | Deposit | `deposits/metallicity/is_metal/cgcnn/`, prepared |
 
-A crystal graph convolutional network that answers one question: does DFT give
-this crystal a zero band gap. Metals need denser k-point sampling than
-insulators, so the answer feeds Goldilocks Core's analysis of a structure
-before any other recommendation is made.
+This model answers one question: **does DFT give this crystal a zero band gap?**
+If it does, we call the crystal a metal.
 
-## Why this exists alongside the published checkpoint
+Goldilocks needs the answer early. Metals need a denser k-point mesh than
+insulators, and they need smearing, which insulators do not. So this is one of
+the first things Core works out about a structure.
 
-`ptc95-vbq12` already publishes a metallicity CGCNN, and this repository ports
-it under `models/k_points/k_distance/qrf/embedding.py`, beside the feature
-contract that consumes it. That port stays exactly where it is,
-because the QRF95 feature contract pins the checkpoint by digest and reads its
-pooled representation.
+## The three things to know
 
-What the published record does not state is how often it is right. It reports
-no test metrics, no split, and no dataset beyond one sentence. A consumer
-serving it can emit `metal` or `insulator` but cannot say with what accuracy,
-which is not a claim Core should make.
+1. **It catches 97.2% of metals**, and to do that it calls about a third of its
+   metals wrongly. That trade is deliberate — see [where the line is
+   drawn](#where-the-line-is-drawn).
+2. **The threshold is 0.066, not 0.5.** A score of 0.2 means metal here.
+3. **Two runs with the same seed give different files** but the same
+   measured numbers, to three decimals.
 
-This trainer fits the same architecture from a sealed snapshot and writes a
-record that states the dataset, the split, the seed, the stopping epoch, and
-the measured performance. The two models never load as each other: this one
-registers under runtime `metallicity.is_metal.cgcnn`.
+## Why there are two metallicity networks
 
-## Data
+PSDI record `ptc95-vbq12` already holds a metallicity CGCNN, and this repository
+uses it — but only for the representation it learned, not for its predictions.
+That code lives in `models/k_points/k_distance/qrf/embedding.py`, next to the
+QRF95 feature contract that consumes it, and stays there. It is pinned there by
+digest, so it does not move.
+
+The problem with the published one is simple: **it never says how often it is
+right.** No test metrics, no split, no dataset beyond a sentence. You can make
+it emit `metal` or `insulator`, but you cannot tell anyone how much to trust
+that, and Core should not make a claim it cannot back.
+
+So this trainer fits the same architecture from a sealed snapshot and writes
+down what the other record is missing: the dataset, the split, the seed, the
+epoch it stopped at, and the measured performance. The two never get confused
+for each other — this one registers under runtime `metallicity.is_metal.cgcnn`.
+
+## The data
 
 [Matbench](https://matbench.materialsproject.org) `mp_is_metal`: 106113
-Materials Project structures labelled by whether their DFT band gap is zero.
-Matminer distributes it with a published SHA-256, so the source is pinned
-without a Materials Project API key.
+Materials Project structures, each labelled by whether its DFT band gap is
+zero. Matminer publishes it with a SHA-256, so we can pin the source without a
+Materials Project API key.
 
 ```bash
 uv run --extra models python scripts/matbench_to_snapshot.py \
     --output local_data/snapshots/mp-is-metal
 ```
 
-The converter makes two choices worth knowing about.
+Two things the converter does that are worth knowing:
 
-**Sample ids are content digests of the crystal**, not row numbers. Re-running
-the conversion on a re-downloaded dataset produces the same ids, and duplicate
-crystals collide by construction rather than being counted twice.
+**Each sample's id is a digest of the crystal itself**, not a row number. Run
+the conversion again on a freshly downloaded dataset and you get the same ids.
+Duplicate crystals collide instead of being counted twice.
 
-**Groups are reduced formulae.** Polymorphs and differently sized cells of one
-composition share a group, so the split cannot put two descriptions of the same
-chemistry on both sides of it. With 78164 groups over 106113 samples the
-constraint costs little.
+**Samples are grouped by reduced formula.** Polymorphs of one composition, and
+the same structure in differently sized cells, all land in the same group — so
+the split cannot put two descriptions of the same chemistry on opposite sides.
+There are 78164 groups across 106113 samples, so this costs very little.
 
-The labels are 46151 metals to 59962 insulators. The split is stratified so
-each part carries that 43.5% metal fraction.
+The labels come out at 46151 metals to 59962 insulators. The split is
+stratified, so every part carries the same 43.5% metal fraction.
 
-## Target
+## What counts as a metal
 
-`goldilocks.is_metal.dft_band_gap_zero.v1` — `metal` when the Materials Project
-DFT band gap is zero, `insulator` otherwise, with `metal` as the positive
-class. The contract names the definition, not just the quantity: a band gap
-computed with a different functional would be a different contract.
+The contract is `goldilocks.is_metal.dft_band_gap_zero.v1`: `metal` when the
+Materials Project DFT band gap is zero, `insulator` otherwise, with `metal` as
+the positive class.
 
-## Features
+The contract names the *definition*, not just the quantity. A band gap computed
+with a different functional would be a different contract, even though it is
+still called a band gap.
 
-`crystal_graph.v1` computes no columns.
+## What the model sees
 
-A graph network consumes the crystal, not a fixed-width row, so there is
-nothing tabular for a feature contract to produce. What this one does is assert
-that the snapshot supplies a structure for every sample and that the atomic
-embedding table is pinned by digest, then leave the structures for the trainer.
-Declaring it keeps a protocol honest about what its model eats, and keeps the
-pinned-artifact machinery working for a model that has no feature matrix.
+The feature contract is `crystal_graph.v1`, and it computes **no columns at
+all**.
 
-Graph construction is shared with the published checkpoint's port: each atom is
-a node carrying its 92-wide entry from `atom_init.json`, joined to at most 12
-neighbours within 10 Å, with interatomic distance on each edge. Both
-classifiers therefore see a crystal the same way, which is what makes their
+A graph network eats the crystal itself, not a fixed-width row, so there is
+nothing tabular to produce. The contract still has a job: it checks that every
+sample comes with a structure, and that the atomic embedding table is pinned by
+digest. Then it hands the structures to the trainer untouched. Declaring it
+keeps the protocol explicit about what the model consumes, and keeps the
+pinned-artifact machinery working for a model with no feature matrix.
+
+Each crystal becomes a graph the same way the published checkpoint builds one:
+
+- every atom is a node, carrying its 92-wide row from `atom_init.json`
+- each node joins up to 12 neighbours within 10 Å
+- each edge carries the interatomic distance
+
+Both networks therefore see a crystal identically, which is what makes their
 numbers comparable.
 
-Graphs are cached in memory. Building one parses a CIF and searches
-neighbours, and evaluation over four splits would otherwise rebuild every
-crystal a second time.
+Graphs are cached in memory, because building one means parsing a CIF and
+searching for neighbours. Without the cache, evaluating four splits would build
+every crystal twice.
 
-## Architecture
+## The network
 
-The published checkpoint's, unchanged, so that a comparison between the two
-means something:
+Same as the published checkpoint, unchanged — otherwise comparing the two would
+mean nothing.
 
 | | |
 | --- | --- |
@@ -103,14 +121,14 @@ means something:
 | Pooling | mean |
 | Classes | 2 |
 
-`model.parameters.architecture` can override any of these, and an unknown key
-is refused rather than ignored.
+`model.parameters.architecture` can override any of these. An unknown key is
+refused rather than quietly ignored.
 
-## Fitting
+## How it was trained
 
-The published checkpoint carries its own training configuration, and where that
-configuration is sound this protocol adopts it: AdamW at a learning rate of
-0.001 with weight decay 1e-4, cross entropy, and no class weighting.
+The published checkpoint came with its own training settings, and where those
+are sound we kept them: AdamW at learning rate 0.001, weight decay 1e-4, cross
+entropy, no class weighting.
 
 ```toml
 [model.parameters]
@@ -123,75 +141,83 @@ scheduler_factor = 0.5
 scheduler_patience = 3
 ```
 
-Two of its settings are not carried over, for reasons worth stating.
+We changed two of its settings.
 
-**OneCycle becomes a plateau schedule.** OneCycle needs its total step budget
-fixed before the first batch, which cannot coexist with stopping when the
-validation loss stops improving. Halving the learning rate on a plateau reaches
-the same place without committing to an epoch count in advance.
+**OneCycle became a plateau schedule.** OneCycle has to know its total number
+of steps before the first batch, which rules out stopping when the validation
+loss flattens. Halving the learning rate on a plateau gets to the same place
+without fixing an epoch count up front.
 
-**Stochastic weight averaging is dropped.** The published run configured it to
-begin at epoch 50 and stopped at epoch 0, so it never took effect there either.
-It is a real improvement worth adding later, but it needs a batch-norm update
-pass over the training set and belongs in a change that can be measured on its
+**Stochastic weight averaging is gone.** The published run set it to start at
+epoch 50 and then stopped at epoch 0, so it never ran there either. It is a
+genuine improvement and worth adding later, but it needs a batch-norm update
+pass over the training set, and that belongs in a change we can measure on its
 own.
 
-Training stops when validation loss has not improved for eight epochs and
-restores the weights from the best one. It never reads the calibration or test
-splits.
+Training stops when the validation loss has not improved for eight epochs, and
+restores the weights from the best epoch. It never looks at the calibration or
+test splits.
 
-`device` selects `cpu`, `mps`, or `cuda`, and defaults to `auto`, which prefers
-an accelerator when one is present. The record states which device actually
-fitted the model, the epoch selected, and the learning rate at every epoch.
+`device` takes `cpu`, `mps`, or `cuda`, and defaults to `auto`, which uses an
+accelerator if there is one. The record states which device actually did the
+fitting, which epoch was selected, and the learning rate at every epoch.
 
 ### What the published run actually did
 
-Its checkpoint records `epochs: 1`, reached `epoch: 0` at `global_step: 2246`,
-and is labelled `run_name: test0`, `experiment_name: cgcnn_basic`. At a batch
-size of 64 that is roughly 144000 samples: a single pass. Reproducing that
-exactly would reproduce a smoke test, which is also the likeliest reason its
-record reports no accuracy.
+Its checkpoint says `epochs: 1`, reached `epoch: 0` at `global_step: 2246`, and
+is labelled `run_name: test0`, `experiment_name: cgcnn_basic`. At batch size 64
+that is roughly 144000 samples — one pass over the data.
 
-## Evaluation
+In other words, it is a smoke test. Reproducing it exactly would reproduce a
+smoke test, and that is very likely why its record reports no accuracy.
 
-The primary metric is Matthews correlation, against a `train_majority`
-baseline. Accuracy, balanced accuracy, precision, recall, F1, MCC, ROC-AUC, and
-PR-AUC are all reported. With a 43.5% positive rate, accuracy alone would be a
-poor summary; balanced accuracy and MCC are the ones to read.
+## How it is scored
 
-### The decision threshold
+The primary metric is Matthews correlation, compared against a `train_majority`
+baseline. Accuracy, balanced accuracy, precision, recall, F1, MCC, ROC-AUC and
+PR-AUC are all reported.
 
-The classifier returns the probability that a structure is metallic. Calling it
-a metal needs a threshold, and here the two mistakes do not cost the same:
+With a 43.5% positive rate, accuracy on its own would be misleading — a model
+that says "insulator" every time scores 0.544. Read balanced accuracy and MCC
+instead.
 
-- **Calling a metal an insulator** understates the mesh the downstream
-  calculation needs. The Fermi surface is undersampled and the resulting number
-  can be wrong without looking wrong.
-- **Calling an insulator a metal** spends compute on a denser mesh than
-  necessary.
+### Where the line is drawn
 
-One is a wrong answer; the other is a bill. Maximising MCC treats them as
-interchangeable, so the protocol constrains the search instead:
+The network returns a probability that a structure is metallic. Turning that
+into a yes or no needs a threshold, and here **the two mistakes do not cost the
+same**:
+
+| Mistake | What happens |
+| --- | --- |
+| A metal called an insulator | The mesh is too coarse. The Fermi surface is undersampled, and the answer can be wrong without looking wrong. |
+| An insulator called a metal | A denser mesh than necessary. It costs compute. |
+
+One gives you a bad number. The other gives you a bigger bill. Picking the
+threshold that maximises MCC treats those as equally bad, so the protocol
+constrains the search instead:
 
 ```toml
 threshold_metric = "mcc"
 min_recall = 0.97
 ```
 
-Read as: *of the thresholds that miss no more than 3% of metals, take the one
-with the best MCC.* The floor is what belongs on the model card; the threshold
-it produces belongs only to these weights. See
-[Choosing a decision threshold](../../protocol.md#choosing-a-decision-threshold).
+That reads: *of all the thresholds that miss no more than 3% of metals, take
+the one with the best MCC.*
 
-The threshold is chosen on the validation split alone and applied unchanged to
-calibration and test — it is a fitted parameter, so choosing it on test would be
-reading the answer. It is written into `model.json` under `decision`, so a
-served model applies the same line rather than leaving each consumer to pick
-one. A record without it is refused at load: a classifier that cannot turn its
-own score into a label is not servable.
+The floor is the part that belongs on the model card — retrain the model and it
+still applies. The threshold it produces, 0.066, belongs to these weights only.
+[Choosing a decision threshold](../../protocol.md#choosing-a-decision-threshold)
+covers the mechanism.
 
-The floor is not free. Buying recall costs precision, and the price rises
-steeply; measured on validation:
+The threshold is chosen on the validation split and applied unchanged to
+calibration and test. It is a fitted parameter, so choosing it on test would be
+reading the answer first. It is written into `model.json` under `decision`, so
+every consumer applies the same line rather than inventing one. A record without
+it is refused at load — a classifier that cannot turn its own score into a
+label is not servable.
+
+**The floor is not free.** Recall is bought with precision, and the price rises
+steeply. Measured on validation:
 
 | Recall floor | Threshold | Precision | MCC | Metals missed | False alarms |
 | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -200,17 +226,18 @@ steeply; measured on validation:
 | **0.97** | **0.066** | **0.666** | **0.616** | **137** | **2227** |
 | 0.99 | 0.023 | 0.554 | 0.453 | 45 | 3655 |
 
-Over 10603 validation samples, 4585 of them metals. Moving from the
-unconstrained threshold to 0.95 saves 420 metals for 1072 extra false alarms;
-moving from 0.97 to 0.99 saves 92 more for 1428. The useful range ends before
-0.99, where 77% of structures would be sent to a dense mesh — against the 100%
-of doing no classification at all.
+That is over 10603 validation samples, 4585 of them metals. Going from the
+unconstrained threshold to 0.95 rescues 420 metals and costs 1072 extra false
+alarms. Going from 0.97 to 0.99 rescues only 92 more and costs 1428. The useful
+range runs out before 0.99, where 77% of all structures would get a dense mesh
+anyway — against the 100% you would get by not classifying at all.
 
-0.97 rather than 0.95 buys margin. A floor is honoured on validation, which is
-a sample: the 0.95 threshold delivers 0.9455 recall on test, below its own
-floor, while the 0.97 threshold delivers 0.9721 and so keeps 0.95 as well.
+**Why 0.97 and not 0.95?** Margin. A floor is honoured on validation, and
+validation is only a sample. The 0.95 threshold delivers 0.9455 recall on test,
+which is below its own floor. The 0.97 threshold delivers 0.9721, which keeps
+0.95 as well.
 
-## Run
+## Running it
 
 ```bash
 uv run goldilocks-ml train validate protocols/metallicity/is_metal/cgcnn/matbench_mp_is_metal.v1.toml \
@@ -223,11 +250,12 @@ uv run goldilocks-ml train run protocols/metallicity/is_metal/cgcnn/matbench_mp_
   --output local_runs/cgcnn-v1
 ```
 
-## Measured results
+## Results
 
 A full run over the sealed snapshot takes about 54 minutes on an Apple M-series
-GPU, stopping at epoch 32 with the weights from epoch 24 restored. The numbers
-below are the release run, `metallicity.is_metal.cgcnn.matbench_mp_is_metal.v1`.
+GPU. It stops at epoch 32 and restores the weights from epoch 24. These are the
+numbers from the release run,
+`metallicity.is_metal.cgcnn.matbench_mp_is_metal.v1`.
 
 | Split | Accuracy | Balanced | Precision | Recall | F1 | MCC | ROC-AUC | PR-AUC |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -236,31 +264,36 @@ below are the release run, `metallicity.is_metal.cgcnn.matbench_mp_is_metal.v1`.
 | **Test** | **0.748** | **0.766** | 0.649 | **0.972** | 0.778 | **0.569** | **0.950** | **0.947** |
 | Test baseline | 0.544 | 0.500 | 0 | 0 | 0 | 0.000 | 0.500 | 0.274 |
 
-The baseline predicts the majority class, so it never finds a metal at all.
+The baseline always predicts the majority class, so it never finds a metal at
+all.
 
-Read ROC-AUC and PR-AUC first: they do not depend on the threshold, so they
+**Read ROC-AUC and PR-AUC first.** Neither depends on the threshold, so they
 measure how well the model *ranks* structures by metallicity. At 0.950 and
-0.947 on test, the ranking is strong. Accuracy and MCC are lower than they
-could be because the threshold is deliberately not set where they peak — the
-recall floor moved it, and the section above records what that cost.
+0.947 on test, that ranking is strong.
 
-Recall on test is 0.972 against a floor of 0.97 chosen on validation, so the
-promise the protocol makes survives the split it was not chosen on.
+Accuracy and MCC look lower than they could be, and that is expected: the
+threshold is deliberately not where they peak. The recall floor moved it, and
+the table above records exactly what that cost.
 
-## Reproducibility
+Recall on test is 0.972, against a floor of 0.97 that was chosen on validation.
+The promise holds on a split it was not chosen on.
 
-This trainer is **not** deterministic, and `model.json` says so. The seed is
-fixed; what varies is the order a GPU adds numbers in, which changes the last
-few digits and compounds over training. [What a run produces](../../run-bundle.md#do-i-get-the-same-file)
-explains the general case.
+## Will I get the same file twice?
+
+**No.** This trainer is not deterministic, and `model.json` says so. The seed is
+fixed; what varies is the order a GPU adds numbers in. That changes the last few
+digits, and the difference compounds over training. [What a run
+produces](../../run-bundle.md#do-i-get-the-same-file) explains the general case.
 
 Measured here: two runs with the same seed and the same splits produced weight
-files with different checksums. Of 106113 scores, 4% were bit identical, the
-average difference was 4e-6, the largest was 8e-4, and one structure changed
-side of the threshold. **Every metric in the table above is unchanged to three
-decimal places.** The model is reproducible as a model, not as a file.
+files with different checksums. Out of 106113 scores, 4% were bit-identical, the
+average difference was 4e-6, the largest was 8e-4, and exactly one structure
+crossed the threshold. **Every metric in the table above was unchanged to three
+decimal places.**
 
-The split, on the other hand, is exactly reproducible. The second run worked out
-its own assignment from the seed rather than copying the first one's
-`splits.csv`, and the two agree row for row — so the set of structures a number
-describes never moves, even when the number wobbles in its last digits.
+So the model reproduces; the file does not.
+
+**The split does reproduce exactly.** The second run worked out its own
+assignment from the seed rather than copying the first run's `splits.csv`, and
+the two agree row for row. The set of structures behind a number never moves,
+even when the number wobbles in its last digits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dev = [
     "ruff>=0.13",
 ]
 docs = [
+    # Executing a notebook without it makes tqdm print a warning naming the
+    # absolute path of the interpreter, which then ships in the cell output.
+    "ipywidgets>=8.1",
     "mkdocs>=1.6.1",
     "mkdocs-jupyter>=0.26.3",
     "mkdocs-material>=9.7.7",


### PR DESCRIPTION
Three problems found while reviewing [the metallicity model page](https://stfc.github.io/goldilocks-ml/training/models/metallicity/is_metal-cgcnn/).

## 1. A local path was on the public site

Both notebook pages carried this, in a cell's stderr output:

```
/Users/<name>/Library/CloudStorage/.../.venv/lib/python3.13/site-packages/tqdm/auto.py:21:
TqdmWarning: IProgress not found...
```

A notebook is committed with its outputs, so whatever the machine that ran it printed goes to the site. Fixed three ways:

- the stderr outputs are cleared from both notebooks;
- `ipywidgets` joins the docs group, so tqdm stops printing the warning on the next run;
- **CI now fails if any `/Users/` or `/home/` path appears under `docs/`** — the guard matters more than this one instance.

## 2. The Open in Colab badge could not work

It failed on the first code cell, both notebooks:

- `goldilocks_ml` is not installable in Colab (not on PyPI, #12);
- the metallicity notebook copies weights from `local_data/`, which is not in the repository — the model is not published yet;
- the QRF notebook reads `model.json` from the repository for the same reason.

The badges are removed rather than left as a promise we cannot keep. They come back when a reader can follow them: #12, plus the records being published. The metallicity notebook now says plainly that it needs a clone.

## 3. The page was hard to read

This is the substantive change. Same facts, same numbers, plainer sentences:

- claim first, qualification second;
- no elliptical constructions (*"The published checkpoint's, unchanged, so that…"*);
- a **three-bullet summary at the top** — 97.2% recall, threshold 0.066 not 0.5, not bit-reproducible — so a reader can stop there;
- headings that say what the section answers: *Where the line is drawn*, *Will I get the same file twice?*, *What counts as a metal*.

Every number in the old page is still in the new one; I diffed the numeric tokens to check. The inbound link from `inference.md` follows the renamed anchor.

`mkdocs build --strict` clean, ruff clean, 276 tests pass.