### PR TITLE
docs(index): drop the synthetic first run

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,28 +17,6 @@ Goldilocks answers those questions with models trained on past calculations.
     Read on if you want to train a model yourself — on your own calculations,
     your own chemistry, or your own definition of "converged".
 
-## Try it in one command
-
-```bash
-uv run goldilocks-ml train run protocols/synthetic/regression.toml \
-  --dataset tests/fixtures/kdist --output local_runs/first
-```
-
-That trains a model on a small dataset included with the repository, so it
-works before you have prepared anything of your own.
-
-Look in `local_runs/first`. Every training run leaves a folder like it,
-containing:
-
-- what the model predicted for each sample, next to the true value;
-- which samples went into training, validation, and testing;
-- how it scored, and how a trivial baseline scored on the same data;
-- a checksum for every file it read or wrote.
-
-The last two matter more than they sound. A score means nothing without knowing
-what a naive guess would have got, and six months from now the checksums are
-how you prove which data produced which model.
-
 ## Train on your own data
 
 You describe a training job in a small configuration file — which dataset,
@@ -47,6 +25,13 @@ a notebook and forgotten.
 
 [Prepare your data](training/your-data.md) covers the format your calculations
 need to be in. [Train a model](training/index.md) walks through a real one.
+
+Every run leaves [one self-contained folder](training/run-bundle.md): what the
+model predicted for each sample next to the true value, which samples went into
+training, validation and testing, how it scored against a trivial baseline, and
+a checksum for every file it read or wrote. A score means nothing without
+knowing what a naive guess would have got, and six months from now the
+checksums are how you prove which data produced which model.
 
 ## Share what you trained
 

--- a/uv.lock
+++ b/uv.lock
@@ -931,6 +931,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "ipywidgets" },
     { name = "mkdocs" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material" },
@@ -956,6 +957,7 @@ dev = [
     { name = "ruff", specifier = ">=0.13" },
 ]
 docs = [
+    { name = "ipywidgets", specifier = ">=8.1" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-jupyter", specifier = ">=0.26.3" },
     { name = "mkdocs-material", specifier = ">=9.7.7" },
@@ -1034,6 +1036,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "ipywidgets"
+version = "8.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/7c/6db60eddf38547353b06d57941f5eee22a990640ce30479fd71a810507f2/ipywidgets-8.1.9.tar.gz", hash = "sha256:bcccba38a6ec3253f7a39c943cea5b9ad01999ce071396171adbc51c6a6a8613", size = 117252, upload-time = "2026-08-18T08:54:24.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/55/298e9b3b864a198234997e87a1471c1b17d7f3546ace6d18fb5cf1ce24b2/ipywidgets-8.1.9-py3-none-any.whl", hash = "sha256:f2b8cbcaae10252b809fbe4d7470db75c09b769a32cbf816d20e5ca6d3c5a79d", size = 140101, upload-time = "2026-08-18T08:54:22.339Z" },
 ]
 
 [[package]]
@@ -1133,6 +1151,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/8b/e739cf9066ad5037a2d4b0a403f06da374fdccb9748221661c8b492d3dbc/jupyterlab_widgets-3.0.17.tar.gz", hash = "sha256:6e61fe21ca8a66039180a5cc52a433e07279d2fee79c8be963e00d55193f17a8", size = 213919, upload-time = "2026-08-18T08:52:17.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/ef/6d27fc118f58cb24886da413545a7efb0853d405fddbfd8b2d9ac09fbed4/jupyterlab_widgets-3.0.17-py3-none-any.whl", hash = "sha256:40ac1e9955acf116c4d995d9bfa082d86ad9ec6d91c4f134827cf5e0a5eb75e0", size = 217292, upload-time = "2026-08-18T08:52:15.47Z" },
 ]
 
 [[package]]
@@ -3450,6 +3477,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/a0/8fd707bcb776a7be556bad06a2ea5fb9bd519df78ef8e26f70ccf0f38bff/webencodings-0.6.1.tar.gz", hash = "sha256:565f9ad031c702dae404e27a099e3e09186a3ab1b9520f06d215502b651fd910", size = 15001, upload-time = "2026-08-15T14:22:57.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/c6/040cbc72480d789a5f40d63fb484d3106554c4dfa2d2b70ad5022057750f/webencodings-0.6.1-py3-none-any.whl", hash = "sha256:7fab6269c8bf237c657876b52058ccb182e861518d1c695c1a9aaa8c1c105d5b", size = 8745, upload-time = "2026-08-15T14:22:56.31Z" },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/60/bc7a980fc78837d6ef8f5940cca4cadc433364503a4c4d42e2a7a0de3231/widgetsnbextension-4.0.16.tar.gz", hash = "sha256:adeea0ae78f0856ee4945f413299801b82a0a01416303301f39a704282a37b73", size = 1111094, upload-time = "2026-08-18T08:52:55.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/95/40e17e20046b7bc820d29d09ae84ec157ec8dd6e6f6cd722626292c31b2e/widgetsnbextension-4.0.16-py3-none-any.whl", hash = "sha256:a31a8774885b96fe825462f5d6496166f0c7cae111195b6465c801d230eb5a4e", size = 2225148, upload-time = "2026-08-18T08:52:53.736Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The front page opened with:

```bash
uv run goldilocks-ml train run protocols/synthetic/regression.toml \
  --dataset tests/fixtures/kdist --output local_runs/first
```

It still works — I ran it, it produces a run bundle in seconds. But it trains on `tests/fixtures/kdist`, a 120-row synthetic test fixture, and the resulting model means nothing. Leading with it makes the same promise the `train-a-model` notebook made before it was deleted: that a toy is worth your first ten seconds.

The section is gone. The one idea worth keeping from it — that every run leaves an auditable folder with the predictions, the splits, the baseline comparison and a checksum per file — is now a paragraph in *Train on your own data*, pointing at [What a run produces](https://stfc.github.io/goldilocks-ml/training/run-bundle/), which already covers it properly.

Nothing linked to the removed anchor. The command itself stays documented in `README.md`, where a smoke test belongs.

`mkdocs build --strict` clean.