### PR TITLE
docs(deposits): index the classifier by its dataset

### DIFF
--- a/deposits/metallicity/is_metal/cgcnn/metadata.json
+++ b/deposits/metallicity/is_metal/cgcnn/metadata.json
@@ -25,7 +25,7 @@
     ]
   },
   "metadata": {
-    "title": "Goldilocks CGCNN metallicity classifier (Matbench mp_is_metal)",
+    "title": "Goldilocks CGCNN metallicity classifier trained on Matbench mp_is_metal",
     "description": "<p>A crystal graph convolutional neural network that predicts whether a periodic material has a zero DFT band gap. Goldilocks uses metallicity to decide how densely reciprocal space must be sampled and whether smearing applies.</p><p>Trained on the Matbench <code>mp_is_metal</code> task: 106113 Materials Project structures, split 70/10/10/10 by reduced composition so that polymorphs of one composition cannot straddle the split, and stratified by label. On the 10625-structure test split it reaches 0.748 accuracy, 0.569 Matthews correlation and 0.950 ROC-AUC, against 0.544 accuracy and 0.000 MCC for a majority-class baseline.</p><p>The decision threshold is 0.0657, not 0.5. It is chosen on the validation split subject to a floor of 0.97 recall, because missing a metal understates the mesh a calculation needs and produces a wrong answer that does not look wrong, while an unnecessary dense mesh only costs compute. Test recall is 0.972 and test precision 0.649: roughly a third of what this model calls metallic is not, and that is a deliberate trade.</p><p>The record contains the weights and <code>model.json</code>, which records the architecture, the feature contract, the target contract, the threshold and the rule that chose it, the digests, and the atomic embedding table it requires from record ptc95-vbq12. It was written by the run that fitted the model.</p>",
     "creators": [
       {
@@ -182,6 +182,9 @@
       },
       {
         "subject": "Density functional theory"
+      },
+      {
+        "subject": "Matbench mp_is_metal"
       }
     ],
     "publisher": "PSDI",

--- a/deposits/metallicity/is_metal/cgcnn/metadata.json
+++ b/deposits/metallicity/is_metal/cgcnn/metadata.json
@@ -25,7 +25,7 @@
     ]
   },
   "metadata": {
-    "title": "Goldilocks CGCNN metallicity classifier trained on Matbench mp_is_metal",
+    "title": "Goldilocks CGCNN metallicity classifier (Matbench mp_is_metal)",
     "description": "<p>A crystal graph convolutional neural network that predicts whether a periodic material has a zero DFT band gap. Goldilocks uses metallicity to decide how densely reciprocal space must be sampled and whether smearing applies.</p><p>Trained on the Matbench <code>mp_is_metal</code> task: 106113 Materials Project structures, split 70/10/10/10 by reduced composition so that polymorphs of one composition cannot straddle the split, and stratified by label. On the 10625-structure test split it reaches 0.748 accuracy, 0.569 Matthews correlation and 0.950 ROC-AUC, against 0.544 accuracy and 0.000 MCC for a majority-class baseline.</p><p>The decision threshold is 0.0657, not 0.5. It is chosen on the validation split subject to a floor of 0.97 recall, because missing a metal understates the mesh a calculation needs and produces a wrong answer that does not look wrong, while an unnecessary dense mesh only costs compute. Test recall is 0.972 and test precision 0.649: roughly a third of what this model calls metallic is not, and that is a deliberate trade.</p><p>The record contains the weights and <code>model.json</code>, which records the architecture, the feature contract, the target contract, the threshold and the rule that chose it, the digests, and the atomic embedding table it requires from record ptc95-vbq12. It was written by the run that fitted the model.</p>",
     "creators": [
       {


### PR DESCRIPTION
`Matbench mp_is_metal` joins `subjects`. That is what PSDI search indexes, and without it the dataset is findable only by someone reading the title or the description.

The title itself stays as it was:

```
Goldilocks CGCNN metallicity classifier (Matbench mp_is_metal)
```

I tried it without the brackets — *"…classifier trained on Matbench mp_is_metal"* — and side by side the bracketed form is better: the model's name stays short, and the dataset sits where a qualifier belongs. The middle commit on this branch is that experiment, reverted.

## The draft says something else

The draft at `dv9a4-asf87` is currently titled *Goldilocks CGCNN metallicity classifier model*, edited in the web form after upload. Whoever submits it should paste the title above in, so that `deposits/` keeps describing what was actually published.

`publish validate` passes.