### PR TITLE
fix(deposits): stop sending domain metadata PSDI throws away

### DIFF
--- a/deposits/k_points/k_distance/qrf/metadata.json
+++ b/deposits/k_points/k_distance/qrf/metadata.json
@@ -8,23 +8,18 @@
     "default_preview": "README.md"
   },
   "custom_fields": {
-    "dsmd": [
-      {
-        "model_family": "quantile random forest",
-        "target": "k_distance",
-        "feature_contract": "qrf_comp_struct_soap_lattice_metal",
-        "quantiles": "0.05, 0.5, 0.95",
-        "scikit_learn_version": "1.7.2",
-        "sklearn_quantile_version": "0.1.1"
-      }
-    ]
+    "dsmd": []
   },
   "metadata": {
     "title": "Goldilocks QRF95 k-mesh recommendation model",
     "description": "<p>A quantile random forest model used by Goldilocks to recommend k-point meshes for periodic DFT calculations. The model predicts k-distance, the maximum spacing between adjacent k-points in reciprocal space, in inverse angstroms, following the convention used by AiiDA-QuantumESPRESSO. Goldilocks converts that continuous value to an integer k-mesh using the reciprocal lattice. The artifact returns the 0.05, 0.5, and 0.95 quantiles and uses the qrf_comp_struct_soap_lattice_metal feature contract.</p><p>The uploaded README and manifest record the feature definition, training target, scope and limitations, artifact checksum, and load-bearing Python library versions. The artifact is a pickle and must only be loaded from a trusted source after checksum verification.</p>",
     "creators": [
       {
-        "affiliations": [{"name": "UKRI STFC"}],
+        "affiliations": [
+          {
+            "name": "UKRI STFC"
+          }
+        ],
         "person_or_org": {
           "family_name": "Yin",
           "given_name": "Junwen",
@@ -47,8 +42,14 @@
           "given_name": "Alin-Marin",
           "family_name": "Elena"
         },
-        "role": {"id": "projectmanager"},
-        "affiliations": [{"name": "UKRI STFC"}]
+        "role": {
+          "id": "projectmanager"
+        },
+        "affiliations": [
+          {
+            "name": "UKRI STFC"
+          }
+        ]
       },
       {
         "person_or_org": {
@@ -57,8 +58,14 @@
           "given_name": "Elena",
           "family_name": "Patyukova"
         },
-        "role": {"id": "projectmember"},
-        "affiliations": [{"name": "UKRI STFC"}]
+        "role": {
+          "id": "projectmember"
+        },
+        "affiliations": [
+          {
+            "name": "UKRI STFC"
+          }
+        ]
       },
       {
         "person_or_org": {
@@ -67,8 +74,14 @@
           "given_name": "Junwen",
           "family_name": "Yin"
         },
-        "role": {"id": "projectmember"},
-        "affiliations": [{"name": "UKRI STFC"}]
+        "role": {
+          "id": "projectmember"
+        },
+        "affiliations": [
+          {
+            "name": "UKRI STFC"
+          }
+        ]
       },
       {
         "person_or_org": {
@@ -77,8 +90,14 @@
           "given_name": "Susmita",
           "family_name": "Basak"
         },
-        "role": {"id": "projectmember"},
-        "affiliations": [{"name": "UKRI STFC"}]
+        "role": {
+          "id": "projectmember"
+        },
+        "affiliations": [
+          {
+            "name": "UKRI STFC"
+          }
+        ]
       },
       {
         "person_or_org": {
@@ -87,8 +106,14 @@
           "given_name": "Jaehoon",
           "family_name": "Cha"
         },
-        "role": {"id": "projectmember"},
-        "affiliations": [{"name": "UKRI STFC"}]
+        "role": {
+          "id": "projectmember"
+        },
+        "affiliations": [
+          {
+            "name": "UKRI STFC"
+          }
+        ]
       },
       {
         "person_or_org": {
@@ -97,8 +122,14 @@
           "given_name": "Gilberto",
           "family_name": "Teobaldi"
         },
-        "role": {"id": "projectmember"},
-        "affiliations": [{"name": "UKRI STFC"}]
+        "role": {
+          "id": "projectmember"
+        },
+        "affiliations": [
+          {
+            "name": "UKRI STFC"
+          }
+        ]
       },
       {
         "person_or_org": {
@@ -107,8 +138,14 @@
           "given_name": "Samuel",
           "family_name": "Pinilla Sanchez"
         },
-        "role": {"id": "projectmember"},
-        "affiliations": [{"name": "UKRI STFC"}]
+        "role": {
+          "id": "projectmember"
+        },
+        "affiliations": [
+          {
+            "name": "UKRI STFC"
+          }
+        ]
       }
     ],
     "rights": [

--- a/deposits/metallicity/is_metal/cgcnn/metadata.json
+++ b/deposits/metallicity/is_metal/cgcnn/metadata.json
@@ -8,21 +8,7 @@
     "default_preview": "README.md"
   },
   "custom_fields": {
-    "dsmd": [
-      {
-        "model_family": "crystal graph convolutional neural network",
-        "target": "is_metal",
-        "target_contract": "goldilocks.is_metal.dft_band_gap_zero.v1",
-        "feature_contract": "crystal_graph.v1",
-        "training_dataset": "Matbench mp_is_metal (106113 Materials Project structures)",
-        "decision_threshold": "0.0657, chosen under a 0.97 recall floor",
-        "test_mcc": "0.569",
-        "test_recall": "0.972",
-        "pytorch_version": "2.13.0",
-        "label_0": "insulator",
-        "label_1": "metal"
-      }
-    ]
+    "dsmd": []
   },
   "metadata": {
     "title": "Goldilocks CGCNN metallicity classifier (Matbench mp_is_metal)",

--- a/deposits/metallicity/representation/cgcnn/metadata.json
+++ b/deposits/metallicity/representation/cgcnn/metadata.json
@@ -8,20 +8,7 @@
     "default_preview": "README.md"
   },
   "custom_fields": {
-    "dsmd": [
-      {
-        "model_family": "crystal graph convolutional neural network",
-        "target": "is_metal",
-        "feature_contract": "cgcnn_radius10_neighbors12_atom_init",
-        "training_dataset": "Materials Project, October 2025 snapshot",
-        "pytorch_lightning_version": "2.5.2",
-        "label_0": "insulator",
-        "label_1": "metal",
-        "role": "feature extractor",
-        "supplies": "64-dimensional pooled crystal representation",
-        "consumed_by": "comp_struct_soap_lattice_metal.v1"
-      }
-    ]
+    "dsmd": []
   },
   "metadata": {
     "title": "Goldilocks CGCNN crystal representation",

--- a/docs/deposit-format.md
+++ b/docs/deposit-format.md
@@ -121,7 +121,17 @@ At minimum, check these fields for every release:
 | `metadata.publisher` | Publication service, currently `PSDI` |
 | `metadata.publication_date` | Date associated with this artifact release |
 | `metadata.version` | Human-readable model release version |
-| `custom_fields.dsmd` | Model family, target, feature contract, and runtime facts |
+| `custom_fields.dsmd` | Leave empty — see below |
+
+`custom_fields.dsmd` is a list of domain-specific metadata objects, and PSDI
+only stores keys it has registered. Anything else is dropped when the record is
+saved, with no error and a 200 response. Our keys were never registered, so the
+block has never reached a record — the published QRF95 record shows
+`custom_fields: {}` — which is why deposits now send an empty list instead of a
+block that looks stored and is not.
+
+The schema still requires the key, so write it as `{"dsmd": []}` rather than
+omitting it.
 
 Creators and contributors serve different purposes. PSDI constructs the
 citation from `creators`; do not add every project member there unless that is


### PR DESCRIPTION
All three deposits carried a `custom_fields.dsmd` block. None of it has ever reached a record.

## What I found

`dsmd` is real and other projects use it — 47 of the 50 newest PSDI records have one. But **PSDI stores only the keys registered on the instance**, and drops the rest when the record is saved, with no error and a 200 response.

The registered keys are namespaced per project:

| Prefix | Keys | Whose |
| --- | ---: | --- |
| `fb_` | 94 | a flow-battery project |
| `bs1500_` | 22 | a quantum-chemistry project |
| `orkim_` | 4 | a catalysis project |
| none | 5 | `smiles`, `inchi`, `number_of_atoms`, `number_of_elements`, `property_types` |

Ours — `model_family`, `target`, `feature_contract`, `decision_threshold` — are not among them, so the whole object came out empty. Draft `dv9a4-asf87` reads `custom_fields: {}`, and so does the **published** QRF95 record `fex36-67b11`.

## What this changes

The block becomes an empty list. The base schema requires the key, so it cannot simply be removed:

```json
"custom_fields": { "dsmd": [] }
```

Nothing is lost. Every fact in it is already in `model.json` — machine-readable, digest-pinned, and the copy our own loader reads — and in the description. The dsmd block was a third copy that could drift from both, reviewed as if it were published, and going nowhere.

`docs/deposit-format.md` now says this, so the next person does not write a block and wait for it to appear.

## If we want it back

Ask PSDI to register a `goldilocks_` key set. The keys we would want are in the diff of this PR and in #40. That is a conversation with PSDI, not a code change, and it can happen at any time — sending an empty list now does not stand in its way.

All three deposits pass `publish validate`; 276 tests pass.