### PR TITLE
docs(deposits): the contributor list the new classifier ships with

### DIFF
--- a/deposits/metallicity/is_metal/cgcnn/metadata.json
+++ b/deposits/metallicity/is_metal/cgcnn/metadata.json
@@ -54,22 +54,6 @@
       {
         "person_or_org": {
           "type": "personal",
-          "name": "Patyukova, Elena",
-          "given_name": "Elena",
-          "family_name": "Patyukova"
-        },
-        "role": {
-          "id": "projectmember"
-        },
-        "affiliations": [
-          {
-            "name": "UKRI STFC"
-          }
-        ]
-      },
-      {
-        "person_or_org": {
-          "type": "personal",
           "name": "Yin, Junwen",
           "given_name": "Junwen",
           "family_name": "Yin"
@@ -134,9 +118,9 @@
       {
         "person_or_org": {
           "type": "personal",
-          "name": "Pinilla Sanchez, Samuel",
-          "given_name": "Samuel",
-          "family_name": "Pinilla Sanchez"
+          "name": "Sparks, Willow",
+          "given_name": "Willow",
+          "family_name": "Sparks"
         },
         "role": {
           "id": "projectmember"


### PR DESCRIPTION
Elena Patyukova and Samuel Pinilla Sanchez have left the project, and Willow Sparks has joined. That changes who appears on deposits made **from now on**, which is the metallicity classifier alone.

```
deposits/metallicity/is_metal/cgcnn/

  Elena, Alin-Marin   projectmanager
  Yin, Junwen         projectmember
  Basak, Susmita      projectmember
  Cha, Jaehoon        projectmember
  Teobaldi, Gilberto  projectmember
  Sparks, Willow      projectmember
```

## The two published deposits are untouched

`deposits/k_points/k_distance/qrf/` and `deposits/metallicity/representation/cgcnn/` keep the seven-name list they were published with, including both departed people, and do not gain Willow Sparks.

Authorship records who did the work. Leaving the project does not undo having contributed to those two models, and joining afterwards does not add you to them. This holds for their next versions too — a new version of a record is the same work, republished.

Creators are unchanged throughout: the citation is Yin, Junwen alone.

`publish validate` passes on all three.

## Still needed by hand

Draft `dv9a4-asf87` already has the two removals, done in the web form. **Willow Sparks still needs adding there** before it is submitted.