### PR TITLE
feat(inference): let a record ship the artifact it depends on

### DIFF
--- a/deposits/metallicity/is_metal/cgcnn/README.md
+++ b/deposits/metallicity/is_metal/cgcnn/README.md
@@ -10,14 +10,19 @@ which an insulator does not.
 ## Files
 
 - `is_metal.pt`: the fitted weights and the architecture they belong to.
+- `atom_init.json`: the atomic embedding table the graphs are built from.
 - `model.json`: architecture, feature contract, target contract, decision
-  threshold and the rule that chose it, digests, and the one supporting
-  artifact this model needs. Written by the run that fitted the model.
+  threshold and the rule that chose it, and digests. Written by the run that
+  fitted the model.
 
-`atom_init.json` is **not** in this record. It is the atomic embedding table
-from record `ptc95-vbq12`, pinned here by digest. A different table produces
-different graphs and therefore different answers, with no error, which is why
-it is pinned rather than bundled.
+Everything needed to run the model is here: download this record and nothing
+else.
+
+`atom_init.json` is the same file as the one in record `ptc95-vbq12`, and
+`model.json` still pins it there by digest, so the copy in this record is
+verified against the original on load. That matters more than it sounds: a
+different embedding table produces different graphs and therefore different
+answers, with no error and nothing to see.
 
 ## Training data
 

--- a/deposits/metallicity/is_metal/cgcnn/manifest.json
+++ b/deposits/metallicity/is_metal/cgcnn/manifest.json
@@ -6,6 +6,11 @@
       "name": "is_metal.pt",
       "size_bytes": 501981,
       "sha256": "68e03802630f0be991987ddfd79fe1254f8ff70f9d6a3b6c6154ee99d71a8f7d"
+    },
+    {
+      "name": "atom_init.json",
+      "size_bytes": 28392,
+      "sha256": "cb90bd2257dbf8cfc4e6b2b6d4348d4616e8e9680f1339b1461137032e0f1894"
     }
   ],
   "inference_requirements": {
@@ -15,7 +20,7 @@
     "target_contract": "goldilocks.is_metal.dft_band_gap_zero.v1",
     "decision_threshold": 0.06568002700805664,
     "requires": [
-      "atom_init.json from PSDI record ptc95-vbq12"
+      "atom_init.json, included in this record (the same file as PSDI record ptc95-vbq12)"
     ],
     "torch": "2.13.0",
     "torch_geometric": "2.8.0.post1"

--- a/src/goldilocks_ml/inference.py
+++ b/src/goldilocks_ml/inference.py
@@ -165,6 +165,7 @@ def required_artifacts(
     record: Mapping[str, Any],
     artifact_directory: Path | None = None,
     overrides: Mapping[str, Path] | None = None,
+    record_directory: Path | None = None,
 ) -> dict[str, Path]:
     """Resolve and verify the supporting artifacts a record declares.
 
@@ -172,6 +173,11 @@ def required_artifacts(
     embeds a metallicity checkpoint. The record pins each by record id and
     digest, so a consumer never needs to know that any of them exist. An
     override supplies a path but does not excuse it from verification.
+
+    A deposit may also ship a copy of a small dependency beside its own
+    ``model.json``, which makes the record self-contained: one download runs
+    the model. A file found there is preferred over the pinned record's copy
+    and is verified against the same digest, so the two cannot drift.
     """
     declared = record.get("requires_artifacts", ())
     if not declared:
@@ -190,7 +196,13 @@ def required_artifacts(
         )
         for item in declared
     ]
-    return resolve(dependencies, default_directory(artifact_directory), overrides)
+    supplied = dict(overrides or {})
+    if record_directory is not None:
+        for dependency in dependencies:
+            beside = Path(record_directory) / dependency.file
+            if dependency.name not in supplied and beside.is_file():
+                supplied[dependency.name] = beside
+    return resolve(dependencies, default_directory(artifact_directory), supplied)
 
 
 def load_model(
@@ -240,7 +252,9 @@ def load_model(
     contract = contract_for(record["target"]["contract"])
     contract.check_units(record["target"].get("units"))
 
-    resolved = required_artifacts(record, artifact_directory, artifacts)
+    resolved = required_artifacts(
+        record, artifact_directory, artifacts, record_directory=directory
+    )
     runtime = record.get("runtime", {})
     predictor = get_predictor(runtime.get("id"))
     model = predictor(record, directory, resolved)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -226,6 +226,58 @@ def test_declared_artifacts_are_resolved_and_verified(
     assert model.predict(structure()).value == pytest.approx(0.22)
 
 
+def test_a_record_may_ship_its_own_dependency(
+    tmp_path: Path, stub_features: None
+) -> None:
+    """A deposit that carries the file is loadable without the pinned record."""
+    directory = tmp_path / "model"
+    directory.mkdir(parents=True)
+    declared = []
+    for name, filename in (
+        ("metallicity_checkpoint", "is_metal.ckpt"),
+        ("metallicity_atom_init", "atom_init.json"),
+    ):
+        beside = directory / filename
+        beside.write_text(f"contents of {filename}", encoding="utf-8")
+        declared.append(
+            {
+                "name": name,
+                "record_id": "ptc95-vbq12",
+                "file": filename,
+                "sha256": sha256_file(beside),
+            }
+        )
+
+    # No artifact store at all: everything the record needs is in the record.
+    model = load_model(
+        write_model(directory, requires_artifacts=declared),
+        artifact_directory=tmp_path / "empty",
+    )
+
+    assert model.predict(structure()).value == pytest.approx(0.22)
+
+
+def test_a_shipped_dependency_is_still_verified(tmp_path: Path) -> None:
+    """Shipping the file beside the record does not excuse it from its digest."""
+    directory = tmp_path / "model"
+    directory.mkdir(parents=True)
+    (directory / "is_metal.ckpt").write_text("something else", encoding="utf-8")
+    declared = [
+        {
+            "name": "metallicity_checkpoint",
+            "record_id": "ptc95-vbq12",
+            "file": "is_metal.ckpt",
+            "sha256": "0" * 64,
+        }
+    ]
+
+    with pytest.raises(ValueError, match="SHA-256"):
+        load_model(
+            write_model(directory, requires_artifacts=declared),
+            artifact_directory=tmp_path / "empty",
+        )
+
+
 def test_a_tampered_artifact_is_refused(tmp_path: Path) -> None:
     """The record pins a digest, so a swapped checkpoint cannot predict."""
     store = tmp_path / "artifacts" / "ptc95-vbq12"


### PR DESCRIPTION
The metallicity classifier record held `is_metal.pt`, `model.json`, `manifest.json` and `README.md` — but not `atom_init.json`, the atomic embedding table its graphs are built from. Running the model meant finding a **second** PSDI record and downloading 28 KB from it.

The table now ships in the record. One download runs the model.

## How

`load_model` prefers a declared dependency found beside `model.json` over the pinned record's copy:

```python
resolved = required_artifacts(
    record, artifact_directory, artifacts, record_directory=directory
)
```

**The pin is unchanged.** `model.json` still names `ptc95-vbq12` and the digest, and the shipped copy is verified against that digest like any other. So:

- the two copies cannot drift — a mismatch is refused at load;
- provenance survives: the record still says where the table came from;
- a consumer with the file in an artifact store still works, unchanged.

Two tests: one loads a record that carries its dependency with no artifact store at all, one proves a shipped file is still refused when its digest is wrong.

## Why bundle rather than pin only

The file is 28 KB. Against that: a cross-record dependency breaks if the other record is ever restricted, moved, or superseded, and it makes the simplest possible use — *download a model and run it* — a two-step operation for no benefit.

The QRF95 record keeps its dependency pinned rather than bundled: its checkpoint is 2 MB and genuinely belongs to the record that publishes it.

## The draft needs the file

Draft `dv9a4-asf87` has neither `atom_init.json` nor the updated `manifest.json` and `README.md`. It needs all three before submission — or a fresh upload.

278 tests pass; `publish validate` passes.