### PR TITLE
feat(deposits): make QRF95's last version stand on its own

### DIFF
--- a/deposits/k_points/k_distance/qrf/README.md
+++ b/deposits/k_points/k_distance/qrf/README.md
@@ -71,15 +71,24 @@ record](https://data-collections.psdi.ac.uk/records/75959-bwa52).
 
 ## Loading it
 
-`model.json` in this record describes the artifact in machine-readable form:
-the serving runtime, the feature contract and its 483 columns in order, the
-target contract, the SHA-256 of the pickle, and the two companion artifacts it
-needs from record `ptc95-vbq12`. With `goldilocks-ml` installed:
+This record holds everything the model needs:
+
+- `QRF95.pkl`: the fitted forest.
+- `is_metal.ckpt`, `atom_init.json`: the metallicity network whose learned
+  representation makes up 64 of the 483 input columns, and the atomic embedding
+  table its graphs are built from. They are the same files as in record
+  `ptc95-vbq12`, and `model.json` still pins them there by digest, so the copies
+  here are verified against the originals on load.
+- `model.json`: the artifact in machine-readable form — the serving runtime, the
+  feature contract and its 483 columns in order, the target contract, and the
+  digests of everything above.
+
+Download this record and nothing else. With `goldilocks-ml` installed:
 
 ```python
 from goldilocks_ml.inference import load_model
 
-model = load_model("path/to/this/record", artifact_directory="path/to/artifacts")
+model = load_model("path/to/this/record")
 prediction = model.predict(structure)  # prediction.value is a k-distance
 ```
 

--- a/deposits/k_points/k_distance/qrf/manifest.json
+++ b/deposits/k_points/k_distance/qrf/manifest.json
@@ -6,6 +6,16 @@
       "name": "QRF95.pkl",
       "size_bytes": 185695399,
       "sha256": "2647b976a57637cc34e4874f3b0ff3436a7c032761b774fdd9e56e69fddaffcc"
+    },
+    {
+      "name": "is_metal.ckpt",
+      "size_bytes": 2009979,
+      "sha256": "964d818de8a155e3219d1bff9f7fca12137a003c5c71ff6b4f1d68d472d4c9d1"
+    },
+    {
+      "name": "atom_init.json",
+      "size_bytes": 28392,
+      "sha256": "cb90bd2257dbf8cfc4e6b2b6d4348d4616e8e9680f1339b1461137032e0f1894"
     }
   ],
   "inference_requirements": {
@@ -14,6 +24,13 @@
     "sklearn_quantile": "0.1.1",
     "feature_contract": "qrf_comp_struct_soap_lattice_metal",
     "target": "k_distance",
-    "quantiles": [0.05, 0.5, 0.95]
+    "quantiles": [
+      0.05,
+      0.5,
+      0.95
+    ],
+    "requires": [
+      "is_metal.ckpt and atom_init.json, included in this record (the same files as PSDI record ptc95-vbq12)"
+    ]
   }
 }

--- a/deposits/k_points/k_distance/qrf/metadata.json
+++ b/deposits/k_points/k_distance/qrf/metadata.json
@@ -169,6 +169,6 @@
     ],
     "publisher": "PSDI",
     "publication_date": "2025-12-08",
-    "version": "v1.0"
+    "version": "v2.0"
   }
 }


### PR DESCRIPTION
QRF95 will not be updated again after this. A record nobody will touch again should carry everything it needs, so the two files it borrowed from `ptc95-vbq12` now ship with it.

```
fex36-67b11  v2.0
├── QRF95.pkl        185 MB
├── is_metal.ckpt      2 MB   ← new
├── atom_init.json    28 KB   ← new
├── model.json                ← new (this is the version that first ships one)
├── manifest.json
└── README.md
```

`model.json` still pins both to `ptc95-vbq12` by digest, so the copies here are **verified against the originals** rather than replacing them. Provenance is unchanged; the dependency is just no longer a second download.

## Verified end to end

Built a directory holding only these files and loaded it with no artifact directory and no overrides:

```
model_id : k_points.k_distance.qrf@comp_struct_soap_lattice_metal.v1
Si       : 0.2174 1/angstrom
```

That matches the value the published record gives, so the bundled copies are the right files.

## Order

**This needs #44 first.** `load_model` only prefers a dependency sitting beside `model.json` once that lands; without it the record is still correct but a consumer must supply an artifact directory.

## Not changed

The description says nothing about the record being final. It is still the only k-distance model that exists, and writing "superseded" into it would be false today.

`publish validate` passes with all six files.