### PR TITLE
docs(models): mark the two published records historical

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,14 +50,16 @@ submitted for review without you looking at it first.
 
 ## Models published this way
 
-| Model | Answers | Record |
+| Model | What it gives you | Record |
 | --- | --- | --- |
-| QRF95 | how dense a k-point mesh needs to be | [fex36-67b11](https://data-collections.psdi.ac.uk/records/fex36-67b11) |
-| CGCNN | whether a material is a metal | [ptc95-vbq12](https://data-collections.psdi.ac.uk/records/ptc95-vbq12) |
+| [QRF95](training/models/k_points/k_distance-qrf.md) | how dense a k-point mesh needs to be | [fex36-67b11](https://data-collections.psdi.ac.uk/records/fex36-67b11) |
+| [CGCNN representation](training/models/metallicity/representation-cgcnn.md) | 64 numbers describing a crystal | [ptc95-vbq12](https://data-collections.psdi.ac.uk/records/ptc95-vbq12) |
 
-Both were reviewed and accepted by the PSDI Data to Knowledge community. Their
-deposit definitions are in `deposits/`, and are the examples to copy when you
-publish your own.
+Both were reviewed and accepted by the PSDI Data to Knowledge community, and
+both are now **historical**: their latest versions are the last, and neither is
+developed here any more. They are kept loadable and citable. Their deposit
+definitions are in `deposits/`, and are the examples to copy when you publish
+your own.
 
 ## Where to go
 

--- a/docs/training/models/index.md
+++ b/docs/training/models/index.md
@@ -50,28 +50,32 @@ name that repeats itself.
 
 | Setting | Kind | Quantity | Family | Status |
 | --- | --- | --- | --- | --- |
-| [k-point mesh](k_points/index.md) | input | `k_distance` | QRF | published, **Core default** |
-| [Metallicity](metallicity/index.md) | property | `is_metal` | CGCNN | trained, ready to deposit |
+| [k-point mesh](k_points/index.md) | input | `k_distance` | QRF | published, **historical** |
+| [Metallicity](metallicity/index.md) | property | `is_metal` | CGCNN | trained, not deposited |
+| [Metallicity](metallicity/representation-cgcnn.md) | property | representation | CGCNN | published, **historical** |
 | [Magnetism](magnetism/index.md) | input | — | — | planned |
 | [Hubbard U](hubbard_u/index.md) | input | — | — | planned |
 
-One published artifact is not in this table: the CGCNN whose pooled
-representation the k-distance feature vector embeds. It was trained on
-metallicity like the classifier above, so it sits under the same setting — but
-what it gives you is a vector rather than an answer, and the second level says
-which:
+**Historical** means the record's latest version is its last. Both published
+records were fitted before this repository existed, from workflows that were
+not versioned protocols, so neither carries a training run anyone can repeat.
+They stay loadable and citable; a successor is a new record, not a new version.
+
+Two of those rows share a setting, because the same architecture trained on the
+same labels can give you two different things. The second level of the name
+says which:
 
 ```text
 deposits/metallicity/is_metal/cgcnn/         a decision
 deposits/metallicity/representation/cgcnn/   64 numbers another model consumes
 ```
 
-Its record says `role: feature_extractor`, and `load_model` declines to serve
-it, naming the reason.
+The representation record says `role: feature_extractor`, and `load_model`
+declines to serve it, naming the reason.
 
 **Input** settings are written into a DFT input file. **Property** settings are
 facts about the material that inform several inputs at once.
 
-**Core default** is the model Core reaches for when the caller names none. It is
-a separate decision from whether a model is good — Core's registry, not this
-one, records it.
+Which model Core reaches for when the caller names none is Core's decision, and
+Core's registry records it — not this table. Core does not read these PSDI
+records at all today; it downloads its own copies from Hugging Face.

--- a/docs/training/models/k_points/index.md
+++ b/docs/training/models/k_points/index.md
@@ -8,7 +8,7 @@ predict a mesh; it predicts one quantity on that ladder and Core finds the rung.
 
 | Quantity | What it is | Model |
 | --- | --- | --- |
-| `k_distance` | Largest spacing between adjacent k-points, Å⁻¹ | [QRF](k_distance-qrf.md) |
+| `k_distance` | Largest spacing between adjacent k-points, Å⁻¹ | [QRF95](k_distance-qrf.md), historical |
 | `k_index` | Position in the ordered table of meshes | none |
 | `k_line_density` | k-points per unit reciprocal length | none |
 | `k_pra` | k-points per reciprocal atom | none |

--- a/docs/training/models/k_points/k_distance-qrf.md
+++ b/docs/training/models/k_points/k_distance-qrf.md
@@ -1,174 +1,67 @@
-# Train QRF95
+# QRF95
 
 | | |
 | --- | --- |
-| Release | `k_points.k_distance.qrf.goldilocks_kdist_ultra.v1` |
-| Runtime | `k_points.k_distance.qrf` |
+| Record | [fex36-67b11](https://data-collections.psdi.ac.uk/records/fex36-67b11), v2.0 |
+| Status | **historical — no longer developed here** |
+| Predicts | `k_distance`, in Å⁻¹ |
 | Target contract | `goldilocks.k_distance.mesh_lower_bound.2pi.v1` |
-| Dataset | `goldilocks-kdist-ultra`, 21053 structures |
+| Runtime | `k_points.k_distance.qrf` |
 | Notebook | [run it yourself](../../../notebooks/k_distance-qrf.ipynb) |
 
-QRF95 answers "how dense does this k-point mesh need to be" — but not as a grid.
-It predicts a **k-distance**: the largest spacing between neighbouring k-points,
-in Å⁻¹, that still gives a converged answer. Smaller means denser. Goldilocks
-Core turns that one number into an actual `4 4 3` grid using the crystal's
-reciprocal lattice, which is why the model does not have to know anything about
-the shape of the cell.
+A quantile random forest that answers "how dense does this k-point mesh need to
+be". It does not predict the three integers — it predicts a **k-distance**, the
+largest spacing between neighbouring k-points that still gives a converged
+answer, and Goldilocks Core turns that one number into an actual grid using the
+crystal's reciprocal lattice.
 
-It predicts three numbers rather than one: a low estimate, a middle one, and a
-high one. The middle one is the recommendation; the outer two say how sure the
-model is, which is worth recording even though nothing downstream acts on them
-today.
+It returns three numbers: a low estimate, the recommendation, and a high one.
 
-## Install the training dependencies
+## This is a historical version
 
-Training this model needs PyTorch and several materials libraries. They are not
-installed by default, because someone who only wants to publish a model should
-not have to wait for them:
+**v2.0 is the last version of this record.** It will not be updated again, and
+this repository is not developing it further.
 
-```bash
-uv sync --extra models
-```
+It was fitted before this repository existed, from a workflow that was not a
+versioned protocol. What is published is the artifact and enough description to
+load it and cite it — not a training run anyone can repeat. The reproduction
+documentation that used to be on this page claimed more than the record can
+support, so it is gone rather than misleading.
 
-## Target contract
+A successor will be a separate record with its own protocol, dataset snapshot
+and measured results, not a new version of this one.
 
-The protocol uses:
+## What the record holds
 
 ```text
-goldilocks.k_distance.mesh_lower_bound.2pi.v1
+fex36-67b11  v2.0
+├── QRF95.pkl        the fitted forest
+├── is_metal.ckpt    the metallicity network whose learned representation
+├── atom_init.json     makes up 64 of the 483 input columns
+├── model.json       runtime, feature contract, column order, digests
+├── manifest.json
+└── README.md
 ```
 
-For reciprocal-vector lengths that include `2π` and a converged mesh
-`(n₁, n₂, n₃)`, the target is:
+v2.0 added `model.json`, which is what makes the record loadable rather than
+only described, and pulled in the two files it used to borrow from
+[ptc95-vbq12](../metallicity/representation-cgcnn.md). Download the record and
+nothing else:
 
-```text
-max(|b₁| / n₁, |b₂| / n₂, |b₃| / n₃)
+```python
+from goldilocks_ml.inference import load_model
+
+model = load_model("path/to/this/record")
+prediction = model.predict(structure)  # prediction.value is a k-distance
 ```
 
-This is the quantity the released QRF95 artifact empirically learned. It is
-not interchangeable with the source dataset's differently defined
-`Goldilocks_k_distance` column.
+## What it does not claim
 
-## Feature contract
+The record declares **no calibration**. The `-0.0016` Å⁻¹ correction the legacy
+Goldilocks application applied to the bounds was fitted under a different rule
+than current software applies, so it is not carried. The median is unaffected
+by it, which means the recommendation stands; the interval is returned with no
+coverage claimed.
 
-`comp_struct_soap_lattice_metal.v1` contains 483 columns in a fixed order:
-
-| Block | Width |
-| --- | ---: |
-| Magpie element properties | 132 |
-| Stoichiometry | 6 |
-| Valence orbitals | 8 |
-| Symmetry and density | 6 |
-| Composition-agnostic averaged SOAP | 252 |
-| Direct/reciprocal lattice and symmetry identifiers | 15 |
-| Frozen metallicity-CGCNN representation | 64 |
-| **Total** | **483** |
-
-The metallicity checkpoint and atomic embedding table are part of the feature
-definition. The protocol pins both PSDI artifacts by SHA-256.
-
-For compatibility with the historical feature contract, a failed
-symmetry/density or lattice descriptor block is replaced by zeros and emits a
-warning naming the affected structure. Other feature failures stop the run.
-
-## Selection and calibration
-
-Each split earns its place.
-
-**Train** fits the estimator. **Validation** selects hyperparameters, scored by
-the mean pinball loss over the three quantiles. Pinball loss is the proper
-scoring rule for quantile estimation; mean absolute error scores only the
-median, so a model chosen on it is chosen on none of its interval behaviour.
-The search grid lives in `[model.parameters.search]` and every trial is
-recorded in `model.json`. **Calibration** fits the conformal correction.
-**Test** is scored once, at the end.
-
-`min_samples_leaf` decides how many training samples each leaf contributes to
-the empirical quantile, so it is the knob that governs interval quality. On
-this dataset the search selects the estimator default of 1, which is the point:
-an unexamined default becomes a decision justified on held-out data and
-recorded with the run.
-
-### Conformal quantile regression
-
-The correction is the finite-sample split-conformal quantile, at rank
-`⌈(n+1)·coverage⌉` of the calibration scores
-`E_i = max(lower_i − y_i, y_i − upper_i)`, applied as `[lower − Q, upper + Q]`.
-
-This diverges from `notebooks/RF-CQR.ipynb` in the historical repository, which
-subtracts the correction from both bounds. That translates the interval rather
-than resizing it, so its width never responds to calibration and the coverage
-guarantee does not hold. That notebook also takes the rank from the test-set
-size rather than the calibration-set size, which coincides only when the two
-splits are equal.
-
-`Q` is negative here, −0.0028: the raw forest intervals are wider than 90%
-coverage requires, so calibration narrows them. Narrowing can push the median
-outside its own interval, and where an interval is narrower than `2|Q|` it can
-invert one. Each endpoint is therefore clamped to the median —
-`lower = min(lower, median)`, `upper = max(upper, median)` — which settles
-both. This is a clamp, not a sort: an inverted pair collapses onto the median
-rather than swapping ends, and the median itself never moves. Coverage cannot
-fall, because a clamped interval contains the calibrated one wherever that was
-ordered and an inverted one covered nothing to begin with. The measured cost is
-nil.
-
-## Run
-
-Prepare and seal a snapshot with stable sample IDs, CIF files, and a composition
-group in the third `id_prop.csv` column. This configuration pins the snapshot it
-reproduces, so it accepts that one and refuses any other; drop the three pin
-fields to run it against your own data. Then:
-
-```bash
-uv run goldilocks-ml train validate protocols/k_points/k_distance/qrf/goldilocks_kdist_ultra.v1.toml \
-  --dataset SNAPSHOT --artifact-directory ARTIFACTS
-
-uv run goldilocks-ml train run protocols/k_points/k_distance/qrf/goldilocks_kdist_ultra.v1.toml \
-  --dataset SNAPSHOT --artifact-directory ARTIFACTS \
-  --output local_runs/qrf-v1
-```
-
-The estimator fits only the training split. The calibration split determines a
-finite-sample conformal correction. Point metrics use the median; the run also
-records interval coverage and mean interval width for every split.
-
-The model directory contains:
-
-- `QRF95.pkl`: the fitted estimator;
-- `calibration.json`: the conformal correction and the rule applied with it;
-- `model.json`: the record that makes the directory self-describing — serving
-  runtime, trainer, feature contract and its parameters, target contract,
-  pinned artifact digests, and calibration.
-
-These are consumed by the `goldilocks_ml` runtime predictor, not by a consumer
-directly. `load_model` applies the calibration and returns an already-calibrated
-`ModelPrediction`; Goldilocks Core converts its value into a mesh and must not
-apply the correction a second time. See [Use a model](../../../inference.md).
-
-`QRF95.pkl` uses Python pickle. Loading executes code, so `model.json` pins its
-SHA-256 and the loader refuses to unpickle a file that does not match.
-
-## Measured results
-
-A full run over the 21053-structure snapshot takes about eight minutes,
-grouped by reduced composition with a 70/10/10/10 split.
-
-| Split | MAE | R² | Interval coverage | Mean width |
-| --- | ---: | ---: | ---: | ---: |
-| Validation | 0.0664 | 0.666 | 89.9% | 0.314 |
-| Calibration | 0.0635 | 0.691 | 90.1% | 0.314 |
-| **Test** | **0.0674** | **0.684** | **89.5%** | **0.307** |
-
-The train-median baseline reaches 0.1433 MAE on test, so the model is 2.1 times
-better. Held-out coverage lands within half a point of the nominal 90%, and the
-median lies inside its own interval for every one of the 21053 samples.
-
-Training MAE of 0.0061 against a test MAE of 0.0674 is the expected gap for an
-unpruned forest, which memorises its training split.
-
-## Reproduction limit
-
-The published `QRF95.pkl` has `random_state=None`. Its exact fitted trees and
-bytes cannot be reproduced. This protocol reproduces the documented method
-with an explicit seed and creates a new, auditable model release.
+`model.json` also records `record_origin: reconstructed` — it was written after
+the fact, not by the run that fitted the forest.

--- a/docs/training/models/metallicity/representation-cgcnn.md
+++ b/docs/training/models/metallicity/representation-cgcnn.md
@@ -2,11 +2,11 @@
 
 | | |
 | --- | --- |
-| Record | [ptc95-vbq12](https://data-collections.psdi.ac.uk/records/ptc95-vbq12) |
+| Record | [ptc95-vbq12](https://data-collections.psdi.ac.uk/records/ptc95-vbq12), v2.0 |
+| Status | **historical — no longer developed here** |
 | Role | `feature_extractor` — not a model `load_model` will serve |
 | Supplies | a 64-dimensional pooled crystal representation |
 | Consumed by | the [k-distance model's](../k_points/k_distance-qrf.md) feature contract |
-| Deposit | `deposits/metallicity/representation/cgcnn/` |
 
 A crystal graph convolutional network trained on Materials Project `is_metal`
 labels — published, and used, for the vector in its middle rather than the
@@ -17,15 +17,18 @@ head. What comes out is 64 numbers describing the crystal, and those 64 numbers
 are one block of the 483-column vector the k-distance forest predicts from. The
 class it would have predicted is never asked for.
 
-## Why it is filed here and not beside the classifier
+## This is a historical version
 
-Both networks under this setting are the same architecture trained on the same
-kind of label. What differs is what you get back:
+**v2.0 is the last version of this record.** It will not be updated again.
 
-```text
-metallicity/is_metal/cgcnn/         a decision
-metallicity/representation/cgcnn/   64 numbers another model consumes
-```
+It was not trained in this repository, and the record that survives does not
+describe a training run: no dataset snapshot, no split, no measured results.
+There is nothing here to reproduce, and this page does not pretend otherwise.
+
+[#14](https://github.com/stfc/goldilocks-ml/issues/14) tracks removing the
+dependency on it altogether — embedding one model's intermediate layer in
+another model's feature vector is a legitimate technique and a dependency worth
+being rid of.
 
 ## It cannot be served as a classifier
 
@@ -34,7 +37,7 @@ Its final layer does produce a two-class output. That is not enough to use it.
 A classifier turns a score into a label with a threshold, and a threshold is
 chosen on a held-out split against a stated objective. This record describes no
 split. There is nothing to choose a threshold on, and nothing that says how
-often the resulting answer would be right.
+often the answer would be right.
 
 So its `model.json` records `role: feature_extractor`, and `load_model` refuses
 it by name rather than quietly falling back to 0.5:
@@ -45,32 +48,22 @@ a question; it supplies input to the 'comp_struct_soap_lattice_metal.v1'
 feature contract
 ```
 
-For metallicity prediction with a stated threshold and measured accuracy, use
-[the classifier](is_metal-cgcnn.md).
+## What the record holds
 
-## What the record contains
+```text
+ptc95-vbq12  v2.0
+├── is_metal.ckpt    PyTorch Lightning checkpoint: architecture and weights
+├── atom_init.json   the element-to-feature-vector table its graphs are built from
+├── model.json       architecture, graph construction, digests, and the role
+├── manifest.json
+└── README.md
+```
 
-| File | What it is |
-| --- | --- |
-| `is_metal.ckpt` | PyTorch Lightning checkpoint: architecture and weights |
-| `atom_init.json` | the atomic-number-to-feature-vector table its graphs are built from |
-| `model.json` | architecture, graph construction, digests, and the role above |
-
-The two files are one bundle. Replacing `atom_init.json` with a different
+The first two files are one bundle. Replacing `atom_init.json` with a different
 embedding changes every graph, and therefore every number the representation
-produces — with no error and no warning. That is why the k-distance protocol
-pins both by digest and verifies them before computing anything.
+produces — with no error and no warning. That is why both are pinned by digest
+and verified before anything is computed.
 
-`model.json` was written after the fact rather than by the run that fitted the
-network, and says so in `record_origin`.
-
-## Its days are numbered
-
-Embedding one model's intermediate layer in another model's feature vector is a
-legitimate technique, and it is also a dependency worth removing. It means the
-k-distance model cannot be loaded without a second artifact, and that anyone
-retraining either has to reason about both.
-
-[#14](https://github.com/stfc/goldilocks-ml/issues/14) tracks replacing those
-64 columns with something measured against the alternative, rather than
-inherited.
+v2.0 renamed the record from a classifier to what it actually is, and added
+`model.json`, which was written after the fact rather than by the run that
+fitted the network, and says so in `record_origin`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,15 +59,15 @@ nav:
           - Overview: training/models/index.md
           - k-point mesh:
               - Overview: training/models/k_points/index.md
-              - k-distance / QRF:
-                  - Training: training/models/k_points/k_distance-qrf.md
+              - QRF95 (historical):
+                  - The record: training/models/k_points/k_distance-qrf.md
                   - Notebook: notebooks/k_distance-qrf.ipynb
           - Metallicity:
               - Overview: training/models/metallicity/index.md
               - is-metal / CGCNN:
                   - Training: training/models/metallicity/is_metal-cgcnn.md
                   - Notebook: notebooks/metallicity-cgcnn.ipynb
-              - Representation / CGCNN: training/models/metallicity/representation-cgcnn.md
+              - Representation / CGCNN (historical): training/models/metallicity/representation-cgcnn.md
           - Magnetism: training/models/magnetism/index.md
           - Hubbard U: training/models/hubbard_u/index.md
   - Publish a model: publishing.md


### PR DESCRIPTION
Both PSDI records are now at v2.0 and neither will be updated again. The site should say so, and stop documenting a training reproduction that neither record can support.

## QRF95 — 266 lines to 67

The page was titled *Train QRF95* and walked through the target contract, the feature contract, selection and calibration, conformal quantile regression, the run commands, measured results and the reproduction limit.

Almost all of it described training this repository can run — not the run that produced `fex36-67b11`, which happened before this repository existed. The page claimed more than the record supports, so it is gone rather than misleading.

What is left: what the model predicts, that v2.0 is the last version, what the record holds, how to load it, and what it does not claim (no calibration, `record_origin: reconstructed`).

## The representation record

Same status, same framing. It keeps its two substantive sections — why it cannot be served as a classifier, and why its two files are one bundle — and states plainly that there is nothing to reproduce: no dataset snapshot, no split, no measured results.

## Elsewhere

- the front page's model table says both are historical, and links to their pages;
- the model index's status column reads *published, historical*, with a paragraph saying what that means, and the representation record now has its own row instead of a footnote;
- nav labels them, and *Training* becomes *The record* for QRF95;
- the "Core default" note is corrected: **Core does not read these PSDI records at all.** Its registry downloads from Hugging Face — `STFC-SCD/kpoints-goldilocks-QRF` and `JunwenYin/metallicity-goldilocks-CGCNN`, both pinned by revision.

Both notebooks stay. They run against the published records and are the only working demonstration of the inference seam.

`mkdocs build --strict` clean; 278 tests pass.