### PR TITLE
feat(cgcnn): stop on ROC-AUC, the way the benchmark does

### DIFF
--- a/protocols/metallicity/is_metal/cgcnn/matbench_mp_is_metal.v2.toml
+++ b/protocols/metallicity/is_metal/cgcnn/matbench_mp_is_metal.v2.toml
@@ -1,0 +1,69 @@
+# Metallicity classification from a crystal graph, on Matbench mp_is_metal.
+schema_version = 1
+id = "metallicity.is_metal.cgcnn.matbench_mp_is_metal.v2"
+task = "classification"
+trainer = "cgcnn_classifier"
+
+[dataset]
+target = "is_metal"
+target_contract = "goldilocks.is_metal.dft_band_gap_zero.v1"
+requires = ["structures", "groups"]
+record_id = "matbench_mp_is_metal"
+snapshot_version = "v1"
+manifest_sha256 = "b1c1a6129951baceeda5066ce35273eb395195e3a5028a2544ea1f8bea2207ac"
+
+# Grouped by reduced formula so that polymorphs and differently sized cells of
+# one composition cannot straddle the split, and stratified so that each split
+# carries the dataset's 43.5% metal fraction.
+[split]
+method = "group"
+stratify = true
+train = 0.7
+validation = 0.1
+calibration = 0.1
+test = 0.1
+seed = 42
+
+[features]
+schema = "crystal_graph.v1"
+
+# The 92-wide atomic embedding the architecture expects. Pinned to the record
+# that published it, so a different table cannot silently change the inputs.
+[features.depends_on.atom_init]
+record_id = "ptc95-vbq12"
+file = "atom_init.json"
+sha256 = "cb90bd2257dbf8cfc4e6b2b6d4348d4616e8e9680f1339b1461137032e0f1894"
+
+[model]
+seed = 42
+
+# v1 stopped at epoch 32 after 8 epochs without an improving cross-entropy loss,
+# and reached 0.890 balanced accuracy at its best threshold. The Matbench CGCNN
+# benchmark reaches 0.952 on the same dataset, and its recipe differs in two
+# ways that this protocol adopts: it stops on ROC-AUC rather than on loss, and
+# it waits far longer before deciding a run has finished improving.
+#
+# The split is not adopted. Matbench uses random folds; this protocol groups by
+# reduced formula so polymorphs cannot straddle the split, which is harder and
+# is the number worth quoting.
+[model.parameters]
+epochs = 300
+batch_size = 128
+learning_rate = 0.001
+weight_decay = 0.0001
+patience = 40
+selection_metric = "roc_auc"
+scheduler_factor = 0.5
+scheduler_patience = 10
+
+[evaluation]
+primary_metric = "mcc"
+metrics = ["accuracy", "balanced_accuracy", "precision", "recall", "f1", "mcc", "roc_auc", "pr_auc"]
+baseline = "train_majority"
+threshold_metric = "mcc"
+positive_label = "metal"
+# Missing a metal understates the mesh a downstream calculation needs, and the
+# resulting Fermi-surface undersampling is not visible in the answer. Calling an
+# insulator a metal only spends compute. The floor states which error this
+# protocol refuses; MCC then chooses among the thresholds that honour it.
+min_recall = 0.97

--- a/src/goldilocks_ml/models/metallicity/is_metal/cgcnn/trainer.py
+++ b/src/goldilocks_ml/models/metallicity/is_metal/cgcnn/trainer.py
@@ -34,6 +34,13 @@ if TYPE_CHECKING:
     from goldilocks_ml.snapshot import Sample
 
 TRAINER = "cgcnn_classifier"
+# What an epoch is judged on. Cross entropy is the default. ROC-AUC is what the
+# Matbench CGCNN benchmark stopped on, and it does not move when the decision
+# threshold does, so a protocol that chooses a threshold afterwards can select
+# the epoch on it directly.
+VALIDATION_LOSS = "validation_loss"
+VALIDATION_ROC_AUC = "roc_auc"
+SELECTION_METRICS = frozenset({VALIDATION_LOSS, VALIDATION_ROC_AUC})
 RUNTIME = "metallicity.is_metal.cgcnn"
 RUNTIME_VERSION = 1
 RECORD_SCHEMA_VERSION = 1
@@ -185,12 +192,16 @@ def _parameters(protocol: TrainingProtocol) -> dict[str, Any]:
         "scheduler_factor": 0.5,
         "scheduler_patience": 3,
         "device": "auto",
+        "selection_metric": VALIDATION_LOSS,
         "architecture": {},
     }
     unknown = sorted(set(given) - set(known))
     if unknown:
         raise ValueError(f"unknown {TRAINER} parameter(s): {', '.join(unknown)}")
     settings = {**known, **given}
+    if settings["selection_metric"] not in SELECTION_METRICS:
+        allowed = ", ".join(sorted(SELECTION_METRICS))
+        raise ValueError(f"model.parameters.selection_metric must be one of: {allowed}")
     for name in ("epochs", "batch_size", "patience", "scheduler_patience"):
         value = settings[name]
         if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
@@ -232,17 +243,36 @@ def _epoch_loss(
     criterion: torch.nn.Module,
     batch_size: int,
     device: torch.device,
-) -> float:
-    """Return mean loss over a split without updating anything."""
+) -> tuple[float, list[float]]:
+    """Return mean loss and positive-class scores over a split.
+
+    Both come from one forward pass. Selecting on ROC-AUC would otherwise cost
+    a second pass over the validation split every epoch.
+    """
     model.eval()
     total = 0.0
+    scores: list[float] = []
     with torch.no_grad():
         for start in range(0, len(graphs), batch_size):
             window = list(graphs[start : start + batch_size])
             batch = Batch.from_data_list(window).to(device)
-            loss = criterion(model(batch), targets[start : start + batch_size])
+            logits = model(batch)
+            loss = criterion(logits, targets[start : start + batch_size])
             total += float(loss.detach()) * len(window)
-    return total / len(graphs)
+            scores.extend(
+                float(value) for value in torch.softmax(logits, dim=1)[:, 1].cpu()
+            )
+    return total / len(graphs), scores
+
+
+def _roc_auc(scores: Sequence[float], targets: torch.Tensor) -> float:
+    """Return ROC-AUC of the positive-class scores against binary targets."""
+    from sklearn.metrics import roc_auc_score
+
+    truth = targets.detach().cpu().numpy()
+    if len(set(truth.tolist())) < 2:
+        raise ValueError("validation split carries only one class")
+    return float(roc_auc_score(truth, scores))
 
 
 def fit(protocol: TrainingProtocol, context: TrainingContext) -> FittedModel:
@@ -291,7 +321,12 @@ def fit(protocol: TrainingProtocol, context: TrainingContext) -> FittedModel:
     batch_size = int(settings["batch_size"])
 
     order = torch.randperm(len(train_graphs), generator=_generator(protocol.model.seed))
-    best_loss = float("inf")
+    # What "improving" means. Cross entropy is the default; ROC-AUC is what the
+    # Matbench CGCNN benchmark stopped on, and it is the quantity a threshold is
+    # later chosen from, so a run can select on it directly. Negated, so that
+    # lower is better either way and one comparison serves both.
+    selection = str(settings["selection_metric"])
+    best_objective = float("inf")
     best_state: dict[str, torch.Tensor] = {}
     best_epoch = 0
     history: list[dict[str, float]] = []
@@ -314,20 +349,25 @@ def fit(protocol: TrainingProtocol, context: TrainingContext) -> FittedModel:
             optimiser.step()
             running += float(loss.detach()) * len(indices)
         train_loss = running / len(order)
-        validation_loss = _epoch_loss(
+        validation_loss, validation_scores = _epoch_loss(
             model, validation_graphs, validation_targets, criterion, batch_size, device
         )
-        scheduler.step(validation_loss)
+        validation_roc_auc = _roc_auc(validation_scores, validation_targets)
+        objective = (
+            validation_loss if selection == VALIDATION_LOSS else -validation_roc_auc
+        )
+        scheduler.step(objective)
         history.append(
             {
                 "epoch": epoch,
                 "train_loss": train_loss,
                 "validation_loss": validation_loss,
+                "validation_roc_auc": validation_roc_auc,
                 "learning_rate": optimiser.param_groups[0]["lr"],
             }
         )
-        if validation_loss < best_loss:
-            best_loss = validation_loss
+        if objective < best_objective:
+            best_objective = objective
             best_state = {
                 key: value.detach().cpu().clone()
                 for key, value in model.state_dict().items()
@@ -372,11 +412,14 @@ def fit(protocol: TrainingProtocol, context: TrainingContext) -> FittedModel:
                 "scheduler_factor",
                 "scheduler_patience",
                 "device",
+                "selection_metric",
             )
         },
         training={
             "selected_epoch": best_epoch,
-            "validation_loss": best_loss,
+            "selection_metric": selection,
+            "validation_loss": history[best_epoch - 1]["validation_loss"],
+            "validation_roc_auc": history[best_epoch - 1]["validation_roc_auc"],
             "epochs_run": len(history),
             "criterion": "cross_entropy",
             "optimiser": "adamw",

--- a/tests/test_cgcnn.py
+++ b/tests/test_cgcnn.py
@@ -187,6 +187,32 @@ def test_an_unknown_parameter_is_refused(tmp_path: Path) -> None:
         get_trainer(TRAINER)(protocol, empty_context())
 
 
+def test_an_unknown_selection_metric_is_refused(tmp_path: Path) -> None:
+    protocol = unpinned(tmp_path, selection_metric="f1")
+
+    with pytest.raises(ValueError, match="selection_metric must be one of"):
+        get_trainer(TRAINER)(protocol, empty_context())
+
+
+def test_roc_auc_ranks_rather_than_thresholds() -> None:
+    """The selection metric does not move when a decision threshold does."""
+    from goldilocks_ml.models.metallicity.is_metal.cgcnn.trainer import _roc_auc
+
+    targets = torch.tensor([0, 0, 1, 1])
+
+    assert _roc_auc([0.1, 0.2, 0.3, 0.4], targets) == pytest.approx(1.0)
+    # Every score shifted below any plausible threshold; the ranking is the same.
+    assert _roc_auc([0.01, 0.02, 0.03, 0.04], targets) == pytest.approx(1.0)
+    assert _roc_auc([0.4, 0.3, 0.2, 0.1], targets) == pytest.approx(0.0)
+
+
+def test_roc_auc_needs_both_classes() -> None:
+    from goldilocks_ml.models.metallicity.is_metal.cgcnn.trainer import _roc_auc
+
+    with pytest.raises(ValueError, match="only one class"):
+        _roc_auc([0.1, 0.2], torch.tensor([1, 1]))
+
+
 def test_an_unknown_device_is_refused(tmp_path: Path) -> None:
     """Configuration is checked before data, so this fails without a split."""
     protocol = unpinned(tmp_path, device="tpu")


### PR DESCRIPTION
Our metallicity classifier is a long way below what this architecture achieves on this dataset, and the [Matbench benchmark record](https://matbench.materialsproject.org/Full%20Benchmark%20Data/matbench_v0.1_cgcnnv2019/) says why.

```
                              balanced accuracy      f1
matbench CGCNN v2019                 0.9520        0.9462
ours, v1, at its best threshold      0.8904        0.8799
ours, v1, at the threshold in use    0.7660        0.7784
```

The benchmark ships no code — `run.py` is a docstring saying "code not available" — but `info.json` carries the recipe, and it differs from ours in two ways that matter:

| | Matbench | v1 |
| --- | --- | --- |
| early-stopping patience | **500 epochs** | **8** |
| judged on | **ROC-AUC** | cross-entropy loss |
| batch size | 128 | 128 |
| loss | cross entropy | cross entropy |
| split | random 60/20/20 | grouped by reduced formula |

v1 stopped at epoch 32 and kept epoch 24. That is a model that never finished training.

## What this adds

`selection_metric`, defaulting to `validation_loss` so v1 is unchanged:

```toml
[model.parameters]
epochs = 300
patience = 40
selection_metric = "roc_auc"
scheduler_patience = 10
```

ROC-AUC is the right thing for this protocol to select on, and not only because the benchmark does: it does not move when the decision threshold moves, and this protocol chooses its threshold *after* training under a recall floor. Selecting on cross entropy optimises a proxy for a decision the protocol has not made yet.

Both numbers come from the validation pass that was already running each epoch, so the extra cost is one `roc_auc_score` call.

## Protocol v2

`matbench_mp_is_metal.v2.toml` — the same snapshot pin, the same split (validated: `validation=10603, test=10625`, identical to v1), the same threshold rule. Only the training settings differ, so the comparison is clean.

**The split is deliberately not adopted from Matbench.** Theirs is random; ours groups by reduced formula so polymorphs cannot straddle it. Ours is harder and is the number worth quoting — which also means our result will not equal theirs even if the training is right.

## Running now

The v2 run is going; it will take some hours. Results to follow before anything is deposited.

`ruff` clean, 281 tests pass.