### PR TITLE
docs(historical): cite the paper the two historical records came from

### DIFF
--- a/docs/training/models/k_points/index.md
+++ b/docs/training/models/k_points/index.md
@@ -13,6 +13,10 @@ predict a mesh; it predicts one quantity on that ladder and Core finds the rung.
 | `k_line_density` | k-points per unit reciprocal length | none |
 | `k_pra` | k-points per reciprocal atom | none |
 
+QRF95 was fitted for a published study rather than in this repository, so it
+carries a [citation](k_distance-qrf.md#where-it-comes-from) — dataset,
+reference calculations and training code — in place of results measured here.
+
 !!! note "Core's side"
 
     Core owns the ladder and the conversion onto it, and nothing else. Feature

--- a/docs/training/models/k_points/k_distance-qrf.md
+++ b/docs/training/models/k_points/k_distance-qrf.md
@@ -8,6 +8,7 @@
 | Target contract | `goldilocks.k_distance.mesh_lower_bound.2pi.v1` |
 | Runtime | `k_points.k_distance.qrf` |
 | Notebook | [run it yourself](../../../notebooks/k_distance-qrf.ipynb) |
+| Paper | [Digital Discovery, 2026, **5**, 2968](https://doi.org/10.1039/d5dd00565e) |
 
 A quantile random forest that answers "how dense does this k-point mesh need to
 be". It does not predict the three integers — it predicts a **k-distance**, the
@@ -23,13 +24,47 @@ It returns three numbers: a low estimate, the recommendation, and a high one.
 this repository is not developing it further.
 
 It was fitted before this repository existed, from a workflow that was not a
-versioned protocol. What is published is the artifact and enough description to
-load it and cite it — not a training run anyone can repeat. The reproduction
-documentation that used to be on this page claimed more than the record can
-support, so it is gone rather than misleading.
+versioned protocol. What is published here is the artifact and enough
+description to load it and cite it — not a training run this repository can
+repeat. The reproduction documentation that used to be on this page claimed
+more than the record can support, so it is gone rather than misleading.
+
+The work itself is reproducible; the path runs through the paper below, not
+through this package.
 
 A successor will be a separate record with its own protocol, dataset snapshot
 and measured results, not a new version of this one.
+
+## Where it comes from
+
+The forest was fitted for a published study, and that paper is where the data
+and the method live:
+
+> E. Patyukova, J. Yin, S. Basak, S. Pinilla Sanchez, A. Elena and G. Teobaldi,
+> *Automatic generation of input files with optimised k-point meshes for Quantum
+> ESPRESSO self-consistent field single-point total energy calculations*,
+> Digital Discovery, 2026, **5**, 2968–2982.
+> [doi:10.1039/d5dd00565e](https://doi.org/10.1039/d5dd00565e) ·
+> [preprint](https://arxiv.org/abs/2512.15303)
+
+| | |
+| --- | --- |
+| Structures | 20,178 unique, sampled from MC3D PBEsol-v1 and reduced to primitive cells |
+| Reference calculations | Quantum ESPRESSO SCF, SSSP 1.3 PBEsol efficiency pseudopotentials, Marzari–Vanderbilt cold smearing at 0.01 Ry |
+| Converged target | the first of three consecutive k-distances whose energies agree within 1 meV per atom |
+| Model | random forest on composition, structure, SOAP, lattice and metallicity features, with conformalised quantile regression at 95% |
+| Data | [PSDI 75959-bwa52](https://data-collections.psdi.ac.uk/records/75959-bwa52), CC BY 4.0 |
+| Training code | [stfc/goldilocks_kpoints](https://github.com/stfc/goldilocks_kpoints) |
+| Web application | [goldilocks.streamlit.app](https://goldilocks.streamlit.app/), source at [stfc/goldilocks](https://github.com/stfc/goldilocks) |
+
+The paper reports R² 0.703, MAE 0.067 Å⁻¹, and 95.8% empirical coverage at a
+mean interval width of 0.313 Å⁻¹.
+
+**Those are the paper's numbers, not this record's.** They were measured on the
+deployed model, which applies a conformal calibration this record deliberately
+does not carry — see [what it does not claim](#what-it-does-not-claim). No run
+in this repository produced them and nothing here can rescore them, so they are
+cited as the paper's result and appear in no results table on this site.
 
 ## What the record holds
 

--- a/docs/training/models/metallicity/index.md
+++ b/docs/training/models/metallicity/index.md
@@ -23,7 +23,12 @@ There are two published CGCNNs here, and only one of them answers anything.
 
 The second supplies one block of the k-distance model's feature vector and
 answers no question of its own. [Its page](representation-cgcnn.md) explains
-what that means and why it cannot be served as a classifier.
+what that means, why it cannot be served as a classifier, and which
+[paper](representation-cgcnn.md#where-it-comes-from) trained it.
+
+The two are not two attempts at one task, and their numbers do not belong side
+by side: they were fitted on different datasets, under different splits, for
+different purposes.
 
 !!! note "Core's side"
 

--- a/docs/training/models/metallicity/representation-cgcnn.md
+++ b/docs/training/models/metallicity/representation-cgcnn.md
@@ -7,6 +7,7 @@
 | Role | `feature_extractor` — not a model `load_model` will serve |
 | Supplies | a 64-dimensional pooled crystal representation |
 | Consumed by | the [k-distance model's](../k_points/k_distance-qrf.md) feature contract |
+| Paper | [Digital Discovery, 2026, **5**, 2968](https://doi.org/10.1039/d5dd00565e) |
 
 A crystal graph convolutional network trained on Materials Project `is_metal`
 labels — published, and used, for the vector in its middle rather than the
@@ -22,13 +23,50 @@ class it would have predicted is never asked for.
 **v2.0 is the last version of this record.** It will not be updated again.
 
 It was not trained in this repository, and the record that survives does not
-describe a training run: no dataset snapshot, no split, no measured results.
-There is nothing here to reproduce, and this page does not pretend otherwise.
+describe a training run: no dataset snapshot, no split, no threshold, no
+metrics file. Nothing in the record can be reproduced or rescored from the
+record alone, and this page does not pretend otherwise. What the network was
+and how it scored is documented in the paper below instead.
 
 [#14](https://github.com/stfc/goldilocks-ml/issues/14) tracks removing the
 dependency on it altogether — embedding one model's intermediate layer in
 another model's feature vector is a legitimate technique and a dependency worth
 being rid of.
+
+## Where it comes from
+
+It was trained for the study that produced the [k-distance
+model](../k_points/k_distance-qrf.md), to supply that model's metallicity
+features:
+
+> E. Patyukova, J. Yin, S. Basak, S. Pinilla Sanchez, A. Elena and G. Teobaldi,
+> *Automatic generation of input files with optimised k-point meshes for Quantum
+> ESPRESSO self-consistent field single-point total energy calculations*,
+> Digital Discovery, 2026, **5**, 2968–2982.
+> [doi:10.1039/d5dd00565e](https://doi.org/10.1039/d5dd00565e) ·
+> [preprint](https://arxiv.org/abs/2512.15303)
+
+| | |
+| --- | --- |
+| Labels | Materials Project `is_metal`, downloaded July 2025 |
+| Structures | around 180,000 unique |
+| Reported on the paper's test set | accuracy 0.84, F1 0.83, MCC 0.69 |
+
+Those figures belong to the paper's own test set, and the record carries neither
+that split nor the code that made it.
+
+### They are not comparable to the Matbench CGCNN
+
+The [Matbench classifier](is_metal-cgcnn.md) reports lower numbers, and the
+comparison is meaningless. That model is fitted on a different dataset under a
+different split for a different purpose: it follows the Matbench `mp_is_metal`
+protocol on a sealed snapshot, and its threshold is moved off the peak of MCC
+by a deliberate recall floor. A network selected to produce a useful 64-dimensional
+representation and one selected to answer a question under a stated error
+preference are not two attempts at the same task.
+
+Reading 0.84 against 0.748 as "the older one is better" is exactly the mistake
+that comparing across datasets invites.
 
 ## It cannot be served as a classifier
 
@@ -36,8 +74,9 @@ Its final layer does produce a two-class output. That is not enough to use it.
 
 A classifier turns a score into a label with a threshold, and a threshold is
 chosen on a held-out split against a stated objective. This record describes no
-split. There is nothing to choose a threshold on, and nothing that says how
-often the answer would be right.
+split and pins no threshold. The paper reports how often the network was right
+on a test set the record does not carry, which is a citation, not a decision
+rule — there is still nothing here to choose a threshold on.
 
 So its `model.json` records `role: feature_extractor`, and `load_model` refuses
 it by name rather than quietly falling back to 0.5:


### PR DESCRIPTION
Neither QRF95 nor the CGCNN representation was trained here, and both pages said so without saying where they *were* trained. The work is published:

  Patyukova, Yin, Basak, Pinilla Sanchez, Elena and Teobaldi, Digital
  Discovery, 2026, 5, 2968. doi:10.1039/d5dd00565e

That paper carries what the records cannot — the MC3D PBEsol-v1 sample, the Quantum ESPRESSO settings behind the k-distance target, the Materials Project is_metal labels behind the representation, the training code and the data deposit. So each page cites it and summarises the dataset and reproduction path, rather than claiming there is none.

The paper's figures are attributed to the paper and kept out of any results table. Its k-distance coverage was measured with a conformal calibration fex36-67b11 deliberately does not carry, and its 0.84 accuracy was measured on a test set the representation record does not hold — a number that would otherwise invite a comparison with the Matbench classifier's 0.748, which is a different dataset, split and objective entirely.