### PR TITLE
docs(records): link v2.0 of the two historical records, not v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ logic do not belong in Git.
 
 | Model | PSDI record |
 | --- | --- |
-| QRF95 k-mesh recommendation model | [fex36-67b11](https://data-collections.psdi.ac.uk/records/fex36-67b11) |
-| CGCNN metallicity classifier | [ptc95-vbq12](https://data-collections.psdi.ac.uk/records/ptc95-vbq12) |
+| QRF95 k-mesh recommendation model | [q3bye-wep37](https://data-collections.psdi.ac.uk/records/q3bye-wep37) |
+| CGCNN crystal representation | [m742g-g0k14](https://data-collections.psdi.ac.uk/records/m742g-g0k14) |
 
 ## Training protocol CLI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,8 +52,8 @@ submitted for review without you looking at it first.
 
 | Model | What it gives you | Record |
 | --- | --- | --- |
-| [QRF95](training/models/k_points/k_distance-qrf.md) | how dense a k-point mesh needs to be | [fex36-67b11](https://data-collections.psdi.ac.uk/records/fex36-67b11) |
-| [CGCNN representation](training/models/metallicity/representation-cgcnn.md) | 64 numbers describing a crystal | [ptc95-vbq12](https://data-collections.psdi.ac.uk/records/ptc95-vbq12) |
+| [QRF95](training/models/k_points/k_distance-qrf.md) | how dense a k-point mesh needs to be | [q3bye-wep37](https://data-collections.psdi.ac.uk/records/q3bye-wep37) |
+| [CGCNN representation](training/models/metallicity/representation-cgcnn.md) | 64 numbers describing a crystal | [m742g-g0k14](https://data-collections.psdi.ac.uk/records/m742g-g0k14) |
 
 Both were reviewed and accepted by the PSDI Data to Knowledge community, and
 both are now **historical**: their latest versions are the last, and neither is

--- a/docs/notebooks/k_distance-qrf.ipynb
+++ b/docs/notebooks/k_distance-qrf.ipynb
@@ -8,7 +8,7 @@
     "# What k-point mesh does this crystal need?\n",
     "\n",
     "`k_points.k_distance.qrf` — the quantile random forest published as\n",
-    "[fex36-67b11](https://data-collections.psdi.ac.uk/records/fex36-67b11).\n",
+    "[q3bye-wep37](https://data-collections.psdi.ac.uk/records/q3bye-wep37).\n",
     "\n",
     "Choosing a k-point mesh is guesswork with a cost on both sides: too coarse and\n",
     "the answer is wrong, too fine and the calculation takes longer than it needed\n",
@@ -74,9 +74,9 @@
     "    return target\n",
     "\n",
     "\n",
-    "forest = fetch(\"fex36-67b11\", \"QRF95.pkl\")  # 185 MB, once\n",
-    "checkpoint = fetch(\"ptc95-vbq12\", \"is_metal.ckpt\")  # 2 MB\n",
-    "atom_init = fetch(\"ptc95-vbq12\", \"atom_init.json\")  # 28 KB\n",
+    "forest = fetch(\"q3bye-wep37\", \"QRF95.pkl\")  # 185 MB, once\n",
+    "checkpoint = fetch(\"m742g-g0k14\", \"is_metal.ckpt\")  # 2 MB\n",
+    "atom_init = fetch(\"m742g-g0k14\", \"atom_init.json\")  # 28 KB\n",
     "\n",
     "for path in (forest, checkpoint, atom_init):\n",
     "    print(f\"{path.name:16} {path.stat().st_size / 1e6:8.2f} MB\")"
@@ -393,7 +393,7 @@
     "\n",
     "[Model page](https://stfc.github.io/goldilocks-ml/training/models/k_points/k_distance-qrf/) ·\n",
     "[Inference API](https://stfc.github.io/goldilocks-ml/inference/) ·\n",
-    "[PSDI record](https://data-collections.psdi.ac.uk/records/fex36-67b11)"
+    "[PSDI record](https://data-collections.psdi.ac.uk/records/q3bye-wep37)"
    ]
   }
  ],

--- a/docs/notebooks/metallicity-cgcnn.ipynb
+++ b/docs/notebooks/metallicity-cgcnn.ipynb
@@ -74,7 +74,7 @@
     "# answers change, silently. Its digest is pinned and checked on load.\n",
     "atom_init = work / \"atom_init.json\"\n",
     "if not atom_init.exists():\n",
-    "    urlretrieve(f\"{PSDI}/ptc95-vbq12/files/atom_init.json/content\", atom_init)\n",
+    "    urlretrieve(f\"{PSDI}/m742g-g0k14/files/atom_init.json/content\", atom_init)\n",
     "\n",
     "# The weights and the record. Once this model is deposited both come from a\n",
     "# PSDI record like the table above; until then they come from the repository.\n",

--- a/docs/training/models/k_points/k_distance-qrf.md
+++ b/docs/training/models/k_points/k_distance-qrf.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| Record | [fex36-67b11](https://data-collections.psdi.ac.uk/records/fex36-67b11), v2.0 |
+| Record | [q3bye-wep37](https://data-collections.psdi.ac.uk/records/q3bye-wep37), v2.0 |
 | Status | **historical — no longer developed here** |
 | Predicts | `k_distance`, in Å⁻¹ |
 | Target contract | `goldilocks.k_distance.mesh_lower_bound.2pi.v1` |
@@ -69,7 +69,7 @@ cited as the paper's result and appear in no results table on this site.
 ## What the record holds
 
 ```text
-fex36-67b11  v2.0
+q3bye-wep37  v2.0
 ├── QRF95.pkl        the fitted forest
 ├── is_metal.ckpt    the metallicity network whose learned representation
 ├── atom_init.json     makes up 64 of the 483 input columns
@@ -80,7 +80,7 @@ fex36-67b11  v2.0
 
 v2.0 added `model.json`, which is what makes the record loadable rather than
 only described, and pulled in the two files it used to borrow from
-[ptc95-vbq12](../metallicity/representation-cgcnn.md). Download the record and
+[m742g-g0k14](../metallicity/representation-cgcnn.md). Download the record and
 nothing else:
 
 ```python

--- a/docs/training/models/metallicity/is_metal-cgcnn.md
+++ b/docs/training/models/metallicity/is_metal-cgcnn.md
@@ -28,7 +28,7 @@ the first things Core works out about a structure.
 
 ## Why there are two metallicity networks
 
-PSDI record `ptc95-vbq12` already holds a metallicity CGCNN, and this repository
+PSDI record `m742g-g0k14` already holds a metallicity CGCNN, and this repository
 uses it — but only for the representation it learned, not for its predictions.
 That code lives in `models/k_points/k_distance/qrf/embedding.py`, next to the
 QRF95 feature contract that consumes it, and stays there. It is pinned there by

--- a/docs/training/models/metallicity/representation-cgcnn.md
+++ b/docs/training/models/metallicity/representation-cgcnn.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| Record | [ptc95-vbq12](https://data-collections.psdi.ac.uk/records/ptc95-vbq12), v2.0 |
+| Record | [m742g-g0k14](https://data-collections.psdi.ac.uk/records/m742g-g0k14), v2.0 |
 | Status | **historical — no longer developed here** |
 | Role | `feature_extractor` — not a model `load_model` will serve |
 | Supplies | a 64-dimensional pooled crystal representation |
@@ -90,7 +90,7 @@ feature contract
 ## What the record holds
 
 ```text
-ptc95-vbq12  v2.0
+m742g-g0k14  v2.0
 ├── is_metal.ckpt    PyTorch Lightning checkpoint: architecture and weights
 ├── atom_init.json   the element-to-feature-vector table its graphs are built from
 ├── model.json       architecture, graph construction, digests, and the role


### PR DESCRIPTION
Every link pointed at the record id of the first version. PSDI mints a new id per version, so ptc95-vbq12 and fex36-67b11 are v1.0 and always will be, while the pages around them described v2.0 — its file listing, its rename, its model.json. The links now go to m742g-g0k14 and q3bye-wep37.

This was not cosmetic. model.json exists only in v2.0, and it is the file that makes a record loadable rather than merely described, so anyone who followed a link and downloaded what they found got a record on which the load_model call printed two lines below it fails. The payload files are byte-identical across both versions, so nothing already downloaded is wrong.

README called the representation record a "metallicity classifier", which is the v1.0 title that v2.0 exists to correct.

The protocol's record_id pins and the deposit model.json files still name the v1.0 records and stay as they are: they pin by digest, those digests are the bytes v1.0 holds, and a released protocol is not edited in place.