### PR TITLE
docs(notebooks): re-run the metallicity notebook against the v2 weights

### DIFF
--- a/docs/notebooks/metallicity-cgcnn.ipynb
+++ b/docs/notebooks/metallicity-cgcnn.ipynb
@@ -42,10 +42,10 @@
    "id": "24dc5444",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T09:28:33.776032Z",
-     "iopub.status.busy": "2026-09-02T09:28:33.775903Z",
-     "iopub.status.idle": "2026-09-02T09:28:35.033001Z",
-     "shell.execute_reply": "2026-09-02T09:28:35.032296Z"
+     "iopub.execute_input": "2026-09-03T19:22:57.843669Z",
+     "iopub.status.busy": "2026-09-03T19:22:57.843604Z",
+     "iopub.status.idle": "2026-09-03T19:22:57.851805Z",
+     "shell.execute_reply": "2026-09-03T19:22:57.851445Z"
     }
    },
    "outputs": [
@@ -55,7 +55,7 @@
      "text": [
       "atom_init.json      0.028 MB\n",
       "is_metal.pt         0.502 MB\n",
-      "model.json          0.007 MB\n"
+      "model.json          0.017 MB\n"
      ]
     }
    ],
@@ -93,10 +93,10 @@
    "id": "7b6c08e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T09:28:35.035317Z",
-     "iopub.status.busy": "2026-09-02T09:28:35.035074Z",
-     "iopub.status.idle": "2026-09-02T09:28:37.185998Z",
-     "shell.execute_reply": "2026-09-02T09:28:37.185689Z"
+     "iopub.execute_input": "2026-09-03T19:22:57.853073Z",
+     "iopub.status.busy": "2026-09-03T19:22:57.853024Z",
+     "iopub.status.idle": "2026-09-03T19:22:59.046147Z",
+     "shell.execute_reply": "2026-09-03T19:22:59.045699Z"
     }
    },
    "outputs": [
@@ -133,10 +133,10 @@
    "id": "63db219b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T09:28:37.187332Z",
-     "iopub.status.busy": "2026-09-02T09:28:37.187218Z",
-     "iopub.status.idle": "2026-09-02T09:28:38.031139Z",
-     "shell.execute_reply": "2026-09-02T09:28:38.030752Z"
+     "iopub.execute_input": "2026-09-03T19:22:59.047284Z",
+     "iopub.status.busy": "2026-09-03T19:22:59.047175Z",
+     "iopub.status.idle": "2026-09-03T19:22:59.855298Z",
+     "shell.execute_reply": "2026-09-03T19:22:59.854938Z"
     }
    },
    "outputs": [
@@ -145,12 +145,12 @@
      "output_type": "stream",
      "text": [
       "crystal           says          score   known to be\n",
-      "Cu (fcc)          metal         1.000   metal       \n",
-      "Al (fcc)          metal         0.994   metal       \n",
-      "Fe (bcc)          metal         0.998   metal       \n",
-      "Si (diamond)      metal         0.205   insulator    <-- wrong\n",
-      "NaCl (rocksalt)   insulator     0.016   insulator   \n",
-      "MgO (rocksalt)    insulator     0.064   insulator   \n"
+      "Cu (fcc)          metal         0.984   metal       \n",
+      "Al (fcc)          metal         0.978   metal       \n",
+      "Fe (bcc)          metal         0.992   metal       \n",
+      "Si (diamond)      insulator     0.012   insulator   \n",
+      "NaCl (rocksalt)   insulator     0.006   insulator   \n",
+      "MgO (rocksalt)    insulator     0.008   insulator   \n"
      ]
     }
    ],
@@ -188,18 +188,20 @@
    "id": "577e4ecd",
    "metadata": {},
    "source": [
-    "Five right, one wrong — and the wrong one is the point of this notebook.\n",
+    "Six for six, and none of them close.\n",
     "\n",
-    "**Silicon is a semiconductor**, and the model scores it 0.205. That is well\n",
-    "below halfway, so a naive threshold of 0.5 would have called it an insulator\n",
-    "correctly. The threshold actually in use is *0.066*, and 0.205 clears it.\n",
+    "Every score above sits well clear of both lines: the metals score above 0.97,\n",
+    "the insulators below 0.02, and the threshold in use is *0.0478*. A textbook\n",
+    "crystal is exactly the case a model should find easy, so agreement here is\n",
+    "expected rather than impressive — it does not by itself say anything about\n",
+    "where the threshold matters.\n",
     "\n",
-    "That is not a bug. It is the trade this model is tuned to make, and the next\n",
-    "section is about why.\n",
-    "\n",
-    "Notice MgO too, at 0.064 — a hair under the line. The model is genuinely\n",
-    "uncertain about it, and the line is drawn where uncertainty gets sent to the\n",
-    "expensive-but-safe side."
+    "Where it matters is the structures a real snapshot has that these six do not:\n",
+    "ones the network is genuinely unsure about. [What the floor\n",
+    "costs](#what-the-floor-costs) below measures that on 10 603 real validation\n",
+    "structures instead of six hand-picked ones — 137 metals still missed even\n",
+    "with the floor in place, against 674 if the threshold were left to maximise\n",
+    "MCC instead.\n"
    ]
   },
   {
@@ -219,10 +221,10 @@
    "id": "96c1b13f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T09:28:38.032435Z",
-     "iopub.status.busy": "2026-09-02T09:28:38.032331Z",
-     "iopub.status.idle": "2026-09-02T09:28:38.034505Z",
-     "shell.execute_reply": "2026-09-02T09:28:38.034094Z"
+     "iopub.execute_input": "2026-09-03T19:22:59.856490Z",
+     "iopub.status.busy": "2026-09-03T19:22:59.856386Z",
+     "iopub.status.idle": "2026-09-03T19:22:59.858516Z",
+     "shell.execute_reply": "2026-09-03T19:22:59.858131Z"
     }
    },
    "outputs": [
@@ -235,8 +237,8 @@
       "quantity         is_metal\n",
       "target_contract  goldilocks.is_metal.dft_band_gap_zero.v1\n",
       "confidence       None\n",
-      "details['score']                 0.9996263980865479\n",
-      "details['threshold']             0.06568002700805664\n",
+      "details['score']                 0.9843800067901611\n",
+      "details['threshold']             0.04782969690859318\n",
       "details['label']                 metal\n",
       "details['score_is']              uncalibrated positive-class softmax\n",
       "details['threshold_selected_on'] validation\n",
@@ -279,7 +281,7 @@
    "id": "882fe9a7",
    "metadata": {},
    "source": [
-    "## The line is at 0.066, not 0.5\n",
+    "## The line is at 0.0478, not 0.5\n",
     "\n",
     "`details['threshold']` is far below the halfway point you might expect. That is\n",
     "deliberate, and it is the most important thing about this model.\n",
@@ -296,9 +298,12 @@
     "protocol constrains the search instead: *of the thresholds that miss no more\n",
     "than 3% of metals, take the best one.*\n",
     "\n",
-    "Silicon is what that costs, made concrete: it gets a denser mesh than it needs.\n",
-    "The calculation is still correct, just more expensive. Had the model called a\n",
-    "metal an insulator, the calculation would have been cheap and wrong."
+    "None of the six crystals above happen to sit near that line for this model —\n",
+    "see the note above. What it costs is concrete anyway: 137 real metals in the\n",
+    "validation set still get called insulators even with the floor in place, each\n",
+    "one a mesh too coarse for a Fermi surface the calculation will not know it\n",
+    "missed. The floor's job is to keep that number down, not to reach zero — the\n",
+    "next section is the full trade.\n"
    ]
   },
   {
@@ -307,10 +312,10 @@
    "id": "79244f5c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T09:28:38.035598Z",
-     "iopub.status.busy": "2026-09-02T09:28:38.035546Z",
-     "iopub.status.idle": "2026-09-02T09:28:38.037403Z",
-     "shell.execute_reply": "2026-09-02T09:28:38.037124Z"
+     "iopub.execute_input": "2026-09-03T19:22:59.859543Z",
+     "iopub.status.busy": "2026-09-03T19:22:59.859499Z",
+     "iopub.status.idle": "2026-09-03T19:22:59.861453Z",
+     "shell.execute_reply": "2026-09-03T19:22:59.861156Z"
     }
    },
    "outputs": [
@@ -318,15 +323,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "threshold in use: 0.0657\n",
+      "threshold in use: 0.0478\n",
       "\n",
       "crystal             score  at 0.5      in use      truth      \n",
-      "Cu (fcc)            1.000  metal       metal       metal      \n",
-      "Al (fcc)            0.994  metal       metal       metal      \n",
-      "Fe (bcc)            0.998  metal       metal       metal      \n",
-      "Si (diamond)        0.205  insulator   metal       insulator  \n",
-      "NaCl (rocksalt)     0.016  insulator   insulator   insulator  \n",
-      "MgO (rocksalt)      0.064  insulator   insulator   insulator  \n"
+      "Cu (fcc)            0.984  metal       metal       metal      \n",
+      "Al (fcc)            0.978  metal       metal       metal      \n",
+      "Fe (bcc)            0.992  metal       metal       metal      \n",
+      "Si (diamond)        0.012  insulator   insulator   insulator  \n",
+      "NaCl (rocksalt)     0.006  insulator   insulator   insulator  \n",
+      "MgO (rocksalt)      0.008  insulator   insulator   insulator  \n"
      ]
     }
    ],
@@ -353,19 +358,19 @@
     "\n",
     "| Recall floor | Threshold | Precision | Metals missed | False alarms |\n",
     "| ---: | ---: | ---: | ---: | ---: |\n",
-    "| none (best MCC) | 0.477 | 0.904 | 649 | 420 |\n",
-    "| 0.95 | 0.133 | 0.745 | 229 | 1 492 |\n",
-    "| **0.97** | **0.066** | **0.666** | **137** | **2 227** |\n",
-    "| 0.99 | 0.023 | 0.554 | 45 | 3 655 |\n",
+    "| none (best MCC) | 0.486 | 0.901 | 674 | 431 |\n",
+    "| 0.95 | 0.111 | 0.755 | 228 | 1 414 |\n",
+    "| **0.97** | **0.0478** | **0.669** | **137** | **2 204** |\n",
+    "| 0.99 | 0.015 | 0.555 | 45 | 3 639 |\n",
     "\n",
-    "Going from the unconstrained threshold to 0.95 saves 420 metals for 1 072 extra\n",
-    "false alarms. Going from 0.97 to 0.99 saves 92 more for 1 428. The useful range\n",
+    "Going from the unconstrained threshold to 0.95 saves 446 metals for 983 extra\n",
+    "false alarms. Going from 0.97 to 0.99 saves 92 more for 1 435. The useful range\n",
     "ends before 0.99, where 77% of structures would get a dense mesh anyway —\n",
     "against the 100% of not classifying at all.\n",
     "\n",
     "0.97 rather than 0.95 buys margin: a floor is met on the validation split,\n",
-    "which is a sample. The 0.95 threshold delivers 0.9455 recall on test, below its\n",
-    "own floor. The 0.97 one delivers 0.9721, and so keeps 0.95 as well."
+    "which is a sample. The 0.95 threshold delivers 0.9498 recall on test, below its\n",
+    "own floor. The 0.97 one delivers 0.9717, and so keeps 0.95 as well.\n"
    ]
   },
   {


### PR DESCRIPTION
Its committed outputs were still from the v1 model. The prose built its central example around that: "five right, one wrong" — Silicon scoring 0.205, on the metal side of the naive 0.5 line, rescued only by the 0.066 threshold. That story is gone under v2: the same six textbook crystals now score 6/6 correct, Silicon at 0.012, nowhere near either line.

Re-ran the notebook (uv run jupyter nbconvert --execute --inplace) against the weights already sitting in local_data/models/metallicity/is_metal/cgcnn/ from the v2 deposit, so every printed number is what this model actually does, not a hand-edited guess.

Rewrote rather than patched the three markdown cells that leaned on the old example. Six agreeing crystals cannot demonstrate what a threshold buys — none of them are close enough to it — so "what the floor costs" now points at the real number that does: 137 metals still missed in the validation set even with the floor in place, against 674 if the threshold chased MCC instead. The recall-floor table got the same real numbers this session already put on the model's own page and README, so all three now agree.

Also re-triggered the exact leak #34 fixed once already: nbconvert without the docs group installed drops ipywidgets, and tqdm prints the interpreter's home path into a stderr cell. `uv sync --group docs --extra models` before re-running fixed it at the source instead of hand-stripping the cell output; CI's grep for /Users and /home under docs/ confirms clean.