### PR TITLE
fix(publish): refuse a model card that uses Markdown tables

### DIFF
--- a/src/goldilocks_ml/psdi.py
+++ b/src/goldilocks_ml/psdi.py
@@ -152,6 +152,31 @@ def _validate_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
     return validated
 
 
+def find_markdown_tables(text: str) -> list[int]:
+    """Return the line numbers of any GitHub-flavoured table delimiter rows.
+
+    PSDI renders the model card with a plain Markdown previewer, which has no
+    table extension: a table arrives as a wall of pipes and dashes. Every
+    deposit so far has laid its numbers out as aligned columns inside a fenced
+    block instead, which renders anywhere, and this keeps the next one from
+    finding out the hard way after upload.
+
+    Fenced blocks are skipped, so a card is free to draw a table inside one.
+    """
+    lines: list[int] = []
+    fenced = False
+    for number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            fenced = not fenced
+            continue
+        if fenced or "|" not in stripped or "-" not in stripped:
+            continue
+        if all(character in "|-: \t" for character in stripped):
+            lines.append(number)
+    return lines
+
+
 def load_deposition(directory: Path, artifact_directory: Path) -> Deposition:
     """Load metadata and verify every upload file before any network mutation."""
     directory = directory.resolve()
@@ -187,6 +212,14 @@ def load_deposition(directory: Path, artifact_directory: Path) -> Deposition:
 
     if not readme_path.is_file():
         raise FileNotFoundError(readme_path)
+    table_lines = find_markdown_tables(readme_path.read_text(encoding="utf-8"))
+    if table_lines:
+        numbers = ", ".join(str(number) for number in table_lines)
+        raise ValueError(
+            f"{readme_path.name} uses Markdown tables (line(s) {numbers}), which "
+            "the record page cannot render; lay the values out as aligned "
+            "columns inside a fenced block instead"
+        )
     # Without this a deposit is a file nobody can load: the digests, the
     # feature contract, and the target contract exist only in prose. Both
     # records published before it existed needed one reconstructed afterwards.

--- a/tests/test_psdi.py
+++ b/tests/test_psdi.py
@@ -15,6 +15,7 @@ from goldilocks_ml.psdi import (
     DraftCleanupError,
     create_deposition,
     describe_artifact,
+    find_markdown_tables,
     load_deposition,
     read_token,
     require_upload_confirmation,
@@ -485,3 +486,57 @@ def test_every_shipped_deposit_record_agrees_with_its_manifest(deposit: Path) ->
             continue
         file_name = artifacts[name.removesuffix("_sha256")]
         assert published[file_name] == digest, file_name
+
+
+@pytest.mark.parametrize(
+    "card",
+    [
+        "| split | mae |\n| --- | --- |\n| test | 2.63 |",
+        "|split|mae|\n|---|---|\n|test|2.63|",
+        "| split | mae |\n| :--- | ---: |\n| test | 2.63 |",
+    ],
+)
+def test_a_model_card_with_markdown_tables_is_refused(
+    tmp_path: Path, card: str
+) -> None:
+    """PSDI renders the card with no table extension, so it comes out as pipes."""
+    deposition, artifacts = _write_deposition(tmp_path)
+    (deposition / "README.md").write_text(card, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Markdown tables"):
+        load_deposition(deposition, artifacts)
+
+
+def test_aligned_columns_in_a_fenced_block_are_the_way_to_do_it(tmp_path: Path) -> None:
+    deposition, artifacts = _write_deposition(tmp_path)
+    (deposition / "README.md").write_text(
+        "## Measured performance\n\n"
+        "```text\n"
+        "split          mae      r2\n"
+        "test         2.634   0.042\n"
+        "```\n\n"
+        "A horizontal rule is not a table either:\n\n---\n",
+        encoding="utf-8",
+    )
+
+    assert load_deposition(deposition, artifacts).files["README.md"].is_file()
+
+
+def test_a_table_inside_a_fenced_block_is_left_alone(tmp_path: Path) -> None:
+    """A card may quote a table as an example; only rendered ones are refused."""
+    deposition, artifacts = _write_deposition(tmp_path)
+    (deposition / "README.md").write_text(
+        "This is what not to write:\n\n```markdown\n| a | b |\n| --- | --- |\n```\n",
+        encoding="utf-8",
+    )
+
+    assert load_deposition(deposition, artifacts).files["README.md"].is_file()
+
+
+def test_the_published_model_cards_pass_the_check() -> None:
+    """The convention this enforces was already followed by every deposit."""
+    cards = sorted(Path(__file__).parents[1].glob("deposits/*/*/*/README.md"))
+
+    assert cards
+    for card in cards:
+        assert find_markdown_tables(card.read_text(encoding="utf-8")) == [], card


### PR DESCRIPTION
The k-index card went up with 28 rows of GitHub-flavoured tables and rendered as a wall of pipes and dashes: PSDI previews the card with a plain Markdown renderer that has no table extension. `publish validate` was green throughout, because it checked our own intent and not what the record page can display — the same shape of gap as #39.

Every deposit published so far lays its numbers out as aligned columns inside a fenced block, so the convention existed and was simply not enforced. Loading a deposition now scans README.md for table delimiter rows and refuses one, naming the lines so the fix is obvious. Fenced regions are skipped, so a card may still quote a table as an example of what not to write.

The check covers tables only. It is not a general assurance that the previewer renders everything else, and it says so in the deposit format reference rather than implying more than it does. A test pins all three published cards as passing it, so the rule is the one they already follow.