### PR TITLE
docs(changelog): 0.1.0 is released, not unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.1.0 — unreleased
+## [0.1.0](https://github.com/stfc/goldilocks-ml/releases/tag/v0.1.0) — 2026-09-05
 
-First release.
+First release. `pip install goldilocks-ml`.
 
 ### Train a model
 


### PR DESCRIPTION
The entry was written before the release existed and still said so. It now carries the release date and links the GitHub release, and names the install command, since the whole point of the version is that there is now one.