### PR TITLE
docs(deposits): state that deposits/ mirrors PSDI's latest version

### DIFF
--- a/deposits/README.md
+++ b/deposits/README.md
@@ -10,6 +10,17 @@ PSDI Data Collections is the sole publication target for released model
 artifacts. Runtime consumers resolve PSDI record IDs and do not use a secondary
 model host or fallback source.
 
+## One directory per record, latest version only
+
+`deposits/` mirrors PSDI rather than recording our own history. A model gets a
+directory here when it is deposited, and that directory describes the record's
+**current** version.
+
+When a record gains a new version on PSDI, update its directory in place — new
+checksums in `manifest.json`, new numbers in `README.md`, the same path.
+Superseded versions stay in git history; they do not get a sibling directory or
+a version suffix. A model that is not on PSDI has no directory here.
+
 Validate a locally cached artifact before making any network request:
 
 ```bash


### PR DESCRIPTION
The convention was already the practice — the CGCNN v2 release replaced deposits/metallicity/is_metal/cgcnn in place rather than adding a sibling — but it was nowhere in writing, and the 1-based k-index migration (#70) is about to produce a second version of d5ds2-64f16. Without the rule stated, the obvious move there is a v1/v2 split that would leave the repository holding two descriptions of one record, only one of which is true.